### PR TITLE
Optional fix

### DIFF
--- a/internal/backend/aggregate.go
+++ b/internal/backend/aggregate.go
@@ -12,11 +12,11 @@ import (
 // callbacks for each supported MIR value shape.
 func ResolveAggregateSource(
 	value mir.Value,
-	onLocal func(*mir.LocalValue) (string, error),
-	onName func(*mir.NameValue) (string, error),
-	onLoadPointer func(mir.Value) (string, error),
-	onFieldLoad func(base mir.Value, fieldIndex int) (string, error),
-) (string, error) {
+	onLocal func(*mir.LocalValue) ([]string, string, error),
+	onName func(*mir.NameValue) ([]string, string, error),
+	onLoadPointer func(mir.Value) ([]string, string, error),
+	onFieldLoad func(base mir.Value, fieldIndex int) ([]string, string, error),
+) ([]string, string, error) {
 	switch v := value.(type) {
 	case *mir.LocalValue:
 		if onLocal == nil {
@@ -39,7 +39,7 @@ func ResolveAggregateSource(
 		}
 		return onFieldLoad(v.Base, v.FieldIndex)
 	}
-	return "", fmt.Errorf("unsupported aggregate source %T", value)
+	return nil, "", fmt.Errorf("unsupported aggregate source %T", value)
 }
 
 func ResolveTaggedUnionComposite(target typeinfo.Type, value mir.Value) (mir.Value, mir.Value, bool) {

--- a/internal/backend/aggregate_layout.go
+++ b/internal/backend/aggregate_layout.go
@@ -6,6 +6,7 @@ import (
 	layout "compiler/internal/analysis/layout/model"
 	"compiler/internal/analysis/semantics/typeinfo"
 	"compiler/internal/core/abi"
+	"compiler/internal/tokens"
 )
 
 type AggregateLayoutContext struct {
@@ -80,6 +81,51 @@ func LookupStructLayout(
 		return sliceLikeStructLayout(&typeinfo.RawPtrType{Const: true, Inner: &typeinfo.BuiltinType{Name: "u8"}}), nil
 	case *typeinfo.SliceType:
 		return sliceLikeStructLayout(&typeinfo.RawPtrType{Const: !t.Mutable, Inner: t.Inner}), nil
+	case *typeinfo.OptionalType:
+		if OptionalUsesNiche(t.Inner) {
+			return nil, fmt.Errorf("optional %s uses niche layout", t.Inner)
+		}
+		info, err := TaggedUnionLayoutInfo(AggregateLayoutContext{
+			BackendName:     "shared",
+			ScalarSizeAlign: sharedScalarSizeAlign,
+			LookupNamed:     lookupNamed,
+		}, []typeinfo.Type{t.Inner})
+		if err != nil {
+			return nil, err
+		}
+		payloadSize, payloadAlign, err := aggregateElementSizeAlign(AggregateLayoutContext{
+			BackendName:     "shared",
+			ScalarSizeAlign: sharedScalarSizeAlign,
+			LookupNamed:     lookupNamed,
+		}, t.Inner)
+		if err != nil {
+			return nil, err
+		}
+		return &layout.StructLayout{
+			Fields: []*layout.FieldLayout{
+				{
+					Name:          "$tag",
+					Type:          &typeinfo.BuiltinType{Name: "i32"},
+					SemanticIndex: 0,
+					PhysicalIndex: 0,
+					Offset:        0,
+					Size:          4,
+					Align:         4,
+				},
+				{
+					Name:          "$payload",
+					Type:          t.Inner,
+					SemanticIndex: 1,
+					PhysicalIndex: 1,
+					Offset:        info.PayloadOffset,
+					Size:          payloadSize,
+					Align:         payloadAlign,
+				},
+			},
+			PhysicalOrder: []int{0, 1},
+			Size:          info.Size,
+			Align:         info.Align,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported struct base type %s", typeinfo.FormatType(typ))
 	}
@@ -112,6 +158,28 @@ func sliceLikeStructLayout(ptrType typeinfo.Type) *layout.StructLayout {
 		Size:          ptrSize * 2,
 		Align:         ptrSize,
 	}
+}
+
+func sharedScalarSizeAlign(typ typeinfo.Type) (int64, int64, error) {
+	switch t := typ.(type) {
+	case *typeinfo.BuiltinType:
+		if _, bits, ok := tokens.ParseIntegerBuiltin(t.Name); ok {
+			size := int64((bits + 7) / 8)
+			return size, size, nil
+		}
+		switch t.Name {
+		case "bool":
+			return 1, 1, nil
+		case "char", "f32":
+			return 4, 4, nil
+		case "f64":
+			return 8, 8, nil
+		}
+	case *typeinfo.PointerType, *typeinfo.RefType, *typeinfo.RawPtrType:
+		ptrSize := abi.PointerBytes()
+		return ptrSize, ptrSize, nil
+	}
+	return 0, 0, fmt.Errorf("not a primitive type")
 }
 
 func aggregateElementSizeAlign(ctx AggregateLayoutContext, typ typeinfo.Type) (int64, int64, error) {

--- a/internal/backend/aggregate_layout_test.go
+++ b/internal/backend/aggregate_layout_test.go
@@ -68,3 +68,24 @@ func TestAggregateSizeAlignSupportsErrorUnions(t *testing.T) {
 		t.Fatalf("expected size=16 align=8, got size=%d align=%d", size, align)
 	}
 }
+
+func TestLookupStructLayoutSupportsTaggedOptional(t *testing.T) {
+	lookupNamed := func(*typeinfo.NamedType) (*layout.TypeLayout, error) {
+		t.Fatal("lookupNamed should not be used for builtin tagged optionals")
+		return nil, nil
+	}
+
+	optLayout, err := LookupStructLayout(lookupNamed, &typeinfo.OptionalType{Inner: &typeinfo.BuiltinType{Name: "i32"}})
+	if err != nil {
+		t.Fatalf("lookup optional layout: %v", err)
+	}
+	if got := len(optLayout.Fields); got != 2 {
+		t.Fatalf("expected 2 optional fields, got %d", got)
+	}
+	if optLayout.Fields[0].Name != "$tag" || optLayout.Fields[0].Offset != 0 {
+		t.Fatalf("unexpected optional tag field: %#v", optLayout.Fields[0])
+	}
+	if optLayout.Fields[1].Name != "$payload" || !typeinfo.Equal(optLayout.Fields[1].Type, &typeinfo.BuiltinType{Name: "i32"}) {
+		t.Fatalf("unexpected optional payload field: %#v", optLayout.Fields[1])
+	}
+}

--- a/internal/backend/aggregate_test.go
+++ b/internal/backend/aggregate_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestResolveAggregateSourceLocal(t *testing.T) {
 	value := &mir.LocalValue{LocalID: 1}
-	got, err := ResolveAggregateSource(
+	lines, got, err := ResolveAggregateSource(
 		value,
-		func(v *mir.LocalValue) (string, error) {
+		func(v *mir.LocalValue) ([]string, string, error) {
 			if v != value {
 				t.Fatalf("unexpected local value")
 			}
-			return "%local", nil
+			return nil, "%local", nil
 		},
 		nil,
 		nil,
@@ -22,6 +22,9 @@ func TestResolveAggregateSourceLocal(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 0 {
+		t.Fatalf("expected no prep lines, got %#v", lines)
 	}
 	if got != "%local" {
 		t.Fatalf("expected %%local, got %q", got)
@@ -30,20 +33,23 @@ func TestResolveAggregateSourceLocal(t *testing.T) {
 
 func TestResolveAggregateSourceName(t *testing.T) {
 	value := &mir.NameValue{Path: []string{"Global"}}
-	got, err := ResolveAggregateSource(
+	lines, got, err := ResolveAggregateSource(
 		value,
 		nil,
-		func(v *mir.NameValue) (string, error) {
+		func(v *mir.NameValue) ([]string, string, error) {
 			if v != value {
 				t.Fatalf("unexpected name value")
 			}
-			return "@global", nil
+			return nil, "@global", nil
 		},
 		nil,
 		nil,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 0 {
+		t.Fatalf("expected no prep lines, got %#v", lines)
 	}
 	if got != "@global" {
 		t.Fatalf("expected @global, got %q", got)
@@ -53,20 +59,23 @@ func TestResolveAggregateSourceName(t *testing.T) {
 func TestResolveAggregateSourceLoadPointer(t *testing.T) {
 	ptr := &mir.LocalValue{LocalID: 2}
 	value := &mir.LoadValue{Pointer: ptr}
-	got, err := ResolveAggregateSource(
+	lines, got, err := ResolveAggregateSource(
 		value,
 		nil,
 		nil,
-		func(v mir.Value) (string, error) {
+		func(v mir.Value) ([]string, string, error) {
 			if v != ptr {
 				t.Fatalf("unexpected load pointer")
 			}
-			return "%ptr", nil
+			return nil, "%ptr", nil
 		},
 		nil,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 0 {
+		t.Fatalf("expected no prep lines, got %#v", lines)
 	}
 	if got != "%ptr" {
 		t.Fatalf("expected %%ptr, got %q", got)
@@ -76,20 +85,23 @@ func TestResolveAggregateSourceLoadPointer(t *testing.T) {
 func TestResolveAggregateSourceFieldLoad(t *testing.T) {
 	base := &mir.LocalValue{LocalID: 3}
 	value := &mir.FieldLoadValue{Base: base, FieldIndex: 7}
-	got, err := ResolveAggregateSource(
+	lines, got, err := ResolveAggregateSource(
 		value,
 		nil,
 		nil,
 		nil,
-		func(v mir.Value, index int) (string, error) {
+		func(v mir.Value, index int) ([]string, string, error) {
 			if v != base || index != 7 {
 				t.Fatalf("unexpected field load inputs")
 			}
-			return "%field_addr", nil
+			return []string{"%tmp = add"}, "%field_addr", nil
 		},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 1 || lines[0] != "%tmp = add" {
+		t.Fatalf("unexpected prep lines: %#v", lines)
 	}
 	if got != "%field_addr" {
 		t.Fatalf("expected %%field_addr, got %q", got)
@@ -98,7 +110,7 @@ func TestResolveAggregateSourceFieldLoad(t *testing.T) {
 
 func TestResolveAggregateSourceUnsupported(t *testing.T) {
 	value := &mir.NumberValue{Value: "1"}
-	if _, err := ResolveAggregateSource(value, nil, nil, nil, nil); err == nil {
+	if _, _, err := ResolveAggregateSource(value, nil, nil, nil, nil); err == nil {
 		t.Fatalf("expected unsupported aggregate source error")
 	}
 }

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -3037,15 +3037,23 @@ func lowerAggregateCompositeAssign(state *moduleState, agg *aggregateLocal, comp
 		if !ok {
 			continue
 		}
-		irType, err := llvmBaseType(field.Type)
-		if err != nil {
-			return "", err
-		}
 		addr := llvmLocalName(agg.PtrName)
 		if field.Offset != 0 {
 			tmp := freshTemp(state, "addr")
 			lines = append(lines, fmt.Sprintf("%s = getelementptr inbounds i8, ptr %s, i64 %d", tmp, llvmLocalName(agg.PtrName), field.Offset))
 			addr = tmp
+		}
+		if isAggregateType(state, field.Type) {
+			valueLines, err := lowerAggregateValueToAddr(state, addr, field.Type, val)
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, valueLines...)
+			continue
+		}
+		irType, err := llvmBaseType(field.Type)
+		if err != nil {
+			return "", err
 		}
 		lowered, err := lowerValue(state, val)
 		if err != nil {
@@ -3697,19 +3705,35 @@ func llvmInterfaceReceiverArg(state *moduleState, concrete, receiverType typeinf
 }
 
 func lowerAggregateSource(state *moduleState, value mir.Value) (string, error) {
-	return backend.ResolveAggregateSource(
+	lines, src, err := backend.ResolveAggregateSource(
 		value,
-		func(v *mir.LocalValue) (string, error) { return lowerValue(state, v) },
-		func(v *mir.NameValue) (string, error) { return lowerValue(state, v) },
-		func(v mir.Value) (string, error) { return lowerValue(state, v) },
-		func(base mir.Value, fieldIndex int) (string, error) {
-			_, addr, _, err := lowerFieldAddress(state, base, fieldIndex)
+		func(v *mir.LocalValue) ([]string, string, error) {
+			src, err := lowerValue(state, v)
+			return nil, src, err
+		},
+		func(v *mir.NameValue) ([]string, string, error) {
+			src, err := lowerValue(state, v)
+			return nil, src, err
+		},
+		func(v mir.Value) ([]string, string, error) {
+			src, err := lowerValue(state, v)
+			return nil, src, err
+		},
+		func(base mir.Value, fieldIndex int) ([]string, string, error) {
+			lines, addr, _, err := lowerFieldAddress(state, base, fieldIndex)
 			if err != nil {
-				return "", err
+				return nil, "", err
 			}
-			return addr, nil
+			return lines, addr, nil
 		},
 	)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range lines {
+		state.pendingLines = append(state.pendingLines, line)
+	}
+	return src, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -4815,15 +4839,32 @@ func lowerGlobalComposite(state *moduleState, typ typeinfo.Type, comp *mir.Compo
 			parts = append(parts, fmt.Sprintf("[%d x i8] zeroinitializer", pad))
 			offset = field.Offset
 		}
-		irType, err := llvmBaseType(field.Type)
-		if err != nil {
-			return "", err
-		}
 		val, ok := items[field.Name]
 		if !ok {
+			irType, err := llvmBaseType(field.Type)
+			if err != nil {
+				return "", err
+			}
 			parts = append(parts, fmt.Sprintf("%s zeroinitializer", irType))
 			offset += field.Size
 			continue
+		}
+		if isAggregateType(state, field.Type) {
+			body, err := lowerGlobalComposite(state, field.Type, val.(*mir.CompositeValue))
+			if err != nil {
+				return "", err
+			}
+			typeName, err := llvmABITypeName(state, field.Type)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, fmt.Sprintf("%s { %s }", typeName, body))
+			offset += field.Size
+			continue
+		}
+		irType, err := llvmBaseType(field.Type)
+		if err != nil {
+			return "", err
 		}
 		lit, err := lowerGlobalValue(state, field.Type, val)
 		if err != nil {

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -1881,6 +1881,28 @@ func lowerAggregateCompare(state *moduleState, targetName string, targetType typ
 	if err != nil {
 		return "", true, err
 	}
+	if optValue, _, ok := backend.TaggedOptionalAgainstNone(bin.Left, bin.Right); ok {
+		src, err := lowerAggregateSource(state, optValue)
+		if err != nil {
+			return "", true, err
+		}
+		tag := freshTemp(state, "opt_tag")
+		cmp := freshTemp(state, "opt_is_none")
+		op := "icmp eq"
+		if bin.Op == "!=" {
+			op = "icmp ne"
+		}
+		lines := []string{
+			fmt.Sprintf("%s = load i32, ptr %s", tag, src),
+			fmt.Sprintf("%s = %s i32 %s, 0", cmp, op, tag),
+		}
+		if targetIRType == "i1" || targetIRType == "" {
+			lines = append(lines, fmt.Sprintf("%s = or i1 0, %s", llvmLocalName(targetName), cmp))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s = zext i1 %s to %s", llvmLocalName(targetName), cmp, targetIRType))
+		}
+		return strings.Join(lines, "\n"), true, nil
+	}
 	if _, ok := backend.UnwrapNamed(bin.Left.Type()).(*typeinfo.StringType); ok {
 		if _, ok := backend.UnwrapNamed(bin.Right.Type()).(*typeinfo.StringType); ok {
 			leftBase, err := lowerValue(state, bin.Left)
@@ -3566,6 +3588,16 @@ func ensureLLVMRuntimeTypeInfo(state *moduleState, typ typeinfo.Type) (string, e
 		fmt.Fprintf(state.deferredB,
 			"@%s = private unnamed_addr constant { %s, ptr } { %s %d, %s }\n",
 			metaSym, llvmABIIntType(), llvmABIIntType(), len(desc.Fields), fieldsRef)
+		metaRef = "ptr @" + metaSym
+	case desc.Flags&backend.RuntimeTypeFlagOptional != 0 && desc.Elem != nil:
+		innerSym, err := ensureLLVMRuntimeTypeInfo(state, desc.Elem)
+		if err != nil {
+			return "", err
+		}
+		metaSym := sym + "__meta"
+		fmt.Fprintf(state.deferredB,
+			"@%s = private unnamed_addr constant { ptr, %s } { ptr @%s, %s %d }\n",
+			metaSym, llvmABIIntType(), innerSym, llvmABIIntType(), desc.PayloadOffset)
 		metaRef = "ptr @" + metaSym
 	}
 	fmt.Fprintf(state.deferredB,

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -3243,6 +3243,26 @@ func lowerInterfaceAssign(state *moduleState, dstPtr string, target typeinfo.Typ
 }
 
 func lowerInterfaceConcretePointer(state *moduleState, value mir.Value, concreteType typeinfo.Type) ([]string, string, error) {
+	storedType := becommon.StoredValueType(state.mod, state.fn, state.modules, value)
+	if opt, ok := backend.UnwrapNamed(storedType).(*typeinfo.OptionalType); ok &&
+		!backend.OptionalUsesNiche(opt.Inner) &&
+		typeinfo.Equal(concreteType, opt.Inner) {
+		basePtr, err := lowerStoredAggregatePointer(state, value)
+		if err != nil {
+			return nil, "", err
+		}
+		info, err := llvmUnionLayoutInfo(state, storedType)
+		if err != nil {
+			return nil, "", err
+		}
+		if info.PayloadOffset == 0 {
+			return nil, basePtr, nil
+		}
+		payloadPtr := freshTemp(state, "opt_payload")
+		return []string{
+			fmt.Sprintf("%s = getelementptr inbounds i8, ptr %s, i64 %d", payloadPtr, basePtr, info.PayloadOffset),
+		}, payloadPtr, nil
+	}
 	switch v := value.(type) {
 	case *mir.UnaryValue:
 		if v.Op == "copy" || v.Op == "take" || v.Op == "comptime" {
@@ -3320,6 +3340,12 @@ func lowerNarrowedInterfaceConcrete(state *moduleState, value mir.Value) ([]stri
 		return nil, "", false, nil
 	}
 	storedType := becommon.StoredValueType(state.mod, state.fn, state.modules, value)
+	if opt, ok := backend.UnwrapNamed(storedType).(*typeinfo.OptionalType); ok &&
+		!backend.OptionalUsesNiche(opt.Inner) &&
+		typeinfo.Equal(value.Type(), opt.Inner) {
+		lines, payloadPtr, err := lowerInterfaceConcretePointer(state, value, value.Type())
+		return lines, payloadPtr, err == nil, err
+	}
 	if !isInterfaceAggregate(storedType) {
 		return nil, "", false, nil
 	}
@@ -3329,6 +3355,28 @@ func lowerNarrowedInterfaceConcrete(state *moduleState, value mir.Value) ([]stri
 	}
 	dataPtr := freshTemp(state, "iface_data")
 	return []string{fmt.Sprintf("%s = load ptr, ptr %s", dataPtr, slotPtr)}, dataPtr, true, nil
+}
+
+func lowerStoredAggregatePointer(state *moduleState, value mir.Value) (string, error) {
+	switch v := value.(type) {
+	case *mir.LocalValue:
+		if agg, ok := state.aggLocals[v.LocalID]; ok {
+			return llvmLocalName(agg.PtrName), nil
+		}
+	case *mir.NameValue:
+		if len(v.Path) == 1 {
+			if local := becommon.FindLocalByName(state.fn, v.Path[0]); local != nil {
+				if agg, ok := state.aggLocals[local.ID]; ok {
+					return llvmLocalName(agg.PtrName), nil
+				}
+			}
+		}
+		if v.LinkName != "" {
+			return "@" + becommon.SanitizeIdent(v.LinkName), nil
+		}
+		return "@" + llvmSymbol(state, v.Path), nil
+	}
+	return "", fmt.Errorf("unsupported narrowed aggregate storage %T", value)
 }
 
 func lowerInterfaceDowncastPointer(state *moduleState, value mir.Value, target typeinfo.Type) ([]string, string, error) {

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -527,6 +527,7 @@ fn main() -> void {
 	for _, want := range []string{
 		"load i32, ptr %value",
 		"icmp ne i32",
+		"getelementptr inbounds i8, ptr %value, i64 4",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected %q in llvm output:\n%s", want, text)
@@ -535,6 +536,7 @@ fn main() -> void {
 	for _, bad := range []string{
 		"getelementptr inbounds i8, ptr null, i64 4",
 		"load i32, ptr null",
+		"store ptr %value, ptr %_t",
 	} {
 		if strings.Contains(text, bad) {
 			t.Fatalf("unexpected %q in llvm output:\n%s", bad, text)

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -501,6 +501,47 @@ fn main() -> void {
 	}
 }
 
+func TestLowerTaggedOptionalToLLVM(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+fn main() -> void {
+    let value: ?i32 = 10
+    if value != none {
+        print(value)
+    }
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetLLVM)
+	if err != nil {
+		t.Fatalf("unexpected llvm error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower llvm tagged optional: %v", err)
+	}
+	text := artifact.Text
+	for _, want := range []string{
+		"load i32, ptr %value",
+		"icmp ne i32",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in llvm output:\n%s", want, text)
+		}
+	}
+	for _, bad := range []string{
+		"getelementptr inbounds i8, ptr null, i64 4",
+		"load i32, ptr null",
+	} {
+		if strings.Contains(text, bad) {
+			t.Fatalf("unexpected %q in llvm output:\n%s", bad, text)
+		}
+	}
+}
+
 func TestLowerLocalArrayLiteralAndIndexToLLVM(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "main.fer"), `

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -464,6 +464,43 @@ fn main() -> void {
 	}
 }
 
+func TestLowerStructWithStringFieldToLLVM(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+type Person struct {
+    id: i32
+    name: str
+}
+
+fn main() -> void {
+    let p: Person = .{ .id = 7, .name = "ok" }
+    print(p)
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetLLVM)
+	if err != nil {
+		t.Fatalf("unexpected llvm error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower llvm struct string field: %v", err)
+	}
+	text := artifact.Text
+	for _, want := range []string{
+		"%local__main__Person = type { i32, [4 x i8], { ptr, i64 } }",
+		"call void @llvm.memcpy.p0.p0.i64(",
+		"call void @ferret_global_print(",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in llvm output:\n%s", want, text)
+		}
+	}
+}
+
 func TestLowerLocalArrayLiteralAndIndexToLLVM(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "main.fer"), `

--- a/internal/backend/optional_compare.go
+++ b/internal/backend/optional_compare.go
@@ -1,0 +1,23 @@
+package backend
+
+import (
+	"compiler/internal/analysis/semantics/typeinfo"
+	"compiler/internal/ir/mir"
+)
+
+// TaggedOptionalAgainstNone returns the optional operand when a binary compare
+// is between a tagged optional and `none`. Niche optionals are intentionally
+// excluded because they already lower as scalar/null compares.
+func TaggedOptionalAgainstNone(left, right mir.Value) (mir.Value, *typeinfo.OptionalType, bool) {
+	if _, isNone := left.(*mir.NoneValue); isNone {
+		if opt, ok := UnwrapNamed(right.Type()).(*typeinfo.OptionalType); ok && !OptionalUsesNiche(opt.Inner) {
+			return right, opt, true
+		}
+	}
+	if _, isNone := right.(*mir.NoneValue); isNone {
+		if opt, ok := UnwrapNamed(left.Type()).(*typeinfo.OptionalType); ok && !OptionalUsesNiche(opt.Inner) {
+			return left, opt, true
+		}
+	}
+	return nil, nil, false
+}

--- a/internal/backend/qbe/lower_test.go
+++ b/internal/backend/qbe/lower_test.go
@@ -811,6 +811,7 @@ fn main() -> void {
 	for _, want := range []string{
 		"loaduw %value",
 		"cnew",
+		"add %value, 4",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected %q in qbe output:\n%s", want, text)
@@ -819,6 +820,7 @@ fn main() -> void {
 	for _, bad := range []string{
 		"add 0, 4",
 		"loaduw 0",
+		"copy %value",
 	} {
 		if strings.Contains(text, bad) {
 			t.Fatalf("unexpected %q in qbe output:\n%s", bad, text)

--- a/internal/backend/qbe/lower_test.go
+++ b/internal/backend/qbe/lower_test.go
@@ -748,6 +748,43 @@ fn main() -> void {
 	}
 }
 
+func TestLowerStructWithStringFieldToQBE(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+type Person struct {
+    id: i32
+    name: str
+}
+
+fn main() -> void {
+    let p: Person = .{ .id = 7, .name = "ok" }
+    print(p)
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetQBE)
+	if err != nil {
+		t.Fatalf("unexpected qbe error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower qbe struct string field: %v", err)
+	}
+	text := artifact.Text
+	for _, want := range []string{
+		"type :local__main__Person = { w, b 4, b 16 }",
+		"blit %_t1, %_addr2, 16",
+		"call $ferret_global_print(",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in qbe output:\n%s", want, text)
+		}
+	}
+}
+
 func TestLowerUnionLocalAssignmentToQBE(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "main.fer"), `

--- a/internal/backend/qbe/lower_test.go
+++ b/internal/backend/qbe/lower_test.go
@@ -785,6 +785,47 @@ fn main() -> void {
 	}
 }
 
+func TestLowerTaggedOptionalToQBE(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+fn main() -> void {
+    let value: ?i32 = 10
+    if value != none {
+        print(value)
+    }
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetQBE)
+	if err != nil {
+		t.Fatalf("unexpected qbe error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower qbe tagged optional: %v", err)
+	}
+	text := artifact.Text
+	for _, want := range []string{
+		"loaduw %value",
+		"cnew",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in qbe output:\n%s", want, text)
+		}
+	}
+	for _, bad := range []string{
+		"add 0, 4",
+		"loaduw 0",
+	} {
+		if strings.Contains(text, bad) {
+			t.Fatalf("unexpected %q in qbe output:\n%s", bad, text)
+		}
+	}
+}
+
 func TestLowerUnionLocalAssignmentToQBE(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "main.fer"), `

--- a/internal/backend/qbe/qbe.go
+++ b/internal/backend/qbe/qbe.go
@@ -630,6 +630,24 @@ func lowerAggregateCompare(state *moduleState, targetName string, targetType typ
 	if _, err := qbeBaseType(targetType); err != nil {
 		return "", true, err
 	}
+	if optValue, _, ok := backend.TaggedOptionalAgainstNone(bin.Left, bin.Right); ok {
+		src, err := lowerAggregateSource(state, optValue)
+		if err != nil {
+			return "", true, err
+		}
+		tag := freshTemp(state, "opt_tag")
+		cmp := freshTemp(state, "opt_is_none")
+		lines := []string{
+			fmt.Sprintf("%s =w loaduw %s", tag, src),
+		}
+		if bin.Op == "!=" {
+			lines = append(lines, fmt.Sprintf("%s =w cnew %s, 0", cmp, tag))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s =w ceqw %s, 0", cmp, tag))
+		}
+		lines = append(lines, fmt.Sprintf("%s =w copy %s", qbeLocalName(targetName), cmp))
+		return strings.Join(lines, "\n\t"), true, nil
+	}
 	if _, ok := backend.UnwrapNamed(bin.Left.Type()).(*typeinfo.StringType); ok {
 		if _, ok := backend.UnwrapNamed(bin.Right.Type()).(*typeinfo.StringType); ok {
 			leftBase, err := lowerValue(state, bin.Left)
@@ -1865,6 +1883,14 @@ func ensureQBERuntimeTypeInfo(state *moduleState, typ typeinfo.Type) (string, er
 		}
 		metaSym := sym + "__meta"
 		fmt.Fprintf(state.deferredB, "data $%s = { l %d, l %s }\n", metaSym, len(desc.Fields), fieldsRef)
+		metaRef = "$" + metaSym
+	case desc.Flags&backend.RuntimeTypeFlagOptional != 0 && desc.Elem != nil:
+		innerSym, err := ensureQBERuntimeTypeInfo(state, desc.Elem)
+		if err != nil {
+			return "", err
+		}
+		metaSym := sym + "__meta"
+		fmt.Fprintf(state.deferredB, "data $%s = { l $%s, l %d }\n", metaSym, innerSym, desc.PayloadOffset)
 		metaRef = "$" + metaSym
 	}
 	fmt.Fprintf(state.deferredB, "data $%s = { w %d, z 4, l $%s, l %d, l %d, w %d, z 4, l %s }\n", sym, desc.ID, nameSym, size, align, desc.Flags, metaRef)

--- a/internal/backend/qbe/qbe.go
+++ b/internal/backend/qbe/qbe.go
@@ -1607,6 +1607,26 @@ func lowerInterfaceAssign(state *moduleState, dstPtr string, target typeinfo.Typ
 }
 
 func lowerInterfaceConcretePointer(state *moduleState, value mir.Value, concreteType typeinfo.Type) ([]string, string, error) {
+	storedType := becommon.StoredValueType(state.mod, state.fn, state.modules, value)
+	if opt, ok := backend.UnwrapNamed(storedType).(*typeinfo.OptionalType); ok &&
+		!backend.OptionalUsesNiche(opt.Inner) &&
+		typeinfo.Equal(concreteType, opt.Inner) {
+		basePtr, err := lowerStoredAggregatePointer(state, value)
+		if err != nil {
+			return nil, "", err
+		}
+		info, err := unionLayoutInfo(state, storedType)
+		if err != nil {
+			return nil, "", err
+		}
+		if info.PayloadOffset == 0 {
+			return nil, basePtr, nil
+		}
+		payloadPtr := freshTemp(state, "opt_payload")
+		return []string{
+			fmt.Sprintf("%s =l add %s, %d", payloadPtr, basePtr, info.PayloadOffset),
+		}, payloadPtr, nil
+	}
 	switch v := value.(type) {
 	case *mir.UnaryValue:
 		if v.Op == "copy" || v.Op == "take" || v.Op == "comptime" {
@@ -1641,6 +1661,12 @@ func lowerNarrowedInterfaceConcrete(state *moduleState, value mir.Value) ([]stri
 		return nil, "", false, nil
 	}
 	storedType := becommon.StoredValueType(state.mod, state.fn, state.modules, value)
+	if opt, ok := backend.UnwrapNamed(storedType).(*typeinfo.OptionalType); ok &&
+		!backend.OptionalUsesNiche(opt.Inner) &&
+		typeinfo.Equal(value.Type(), opt.Inner) {
+		lines, payloadPtr, err := lowerInterfaceConcretePointer(state, value, value.Type())
+		return lines, payloadPtr, err == nil, err
+	}
 	if !isInterfaceAggregate(storedType) {
 		return nil, "", false, nil
 	}
@@ -1650,6 +1676,28 @@ func lowerNarrowedInterfaceConcrete(state *moduleState, value mir.Value) ([]stri
 	}
 	dataPtr := freshTemp(state, "iface_data")
 	return []string{fmt.Sprintf("%s =l loadl %s", dataPtr, slotPtr)}, dataPtr, true, nil
+}
+
+func lowerStoredAggregatePointer(state *moduleState, value mir.Value) (string, error) {
+	switch v := value.(type) {
+	case *mir.LocalValue:
+		if agg, ok := state.aggLocals[v.LocalID]; ok {
+			return qbeLocalName(agg.PtrName), nil
+		}
+	case *mir.NameValue:
+		if len(v.Path) == 1 {
+			if local := becommon.FindLocalByName(state.fn, v.Path[0]); local != nil {
+				if agg, ok := state.aggLocals[local.ID]; ok {
+					return qbeLocalName(agg.PtrName), nil
+				}
+			}
+		}
+		if v.LinkName != "" {
+			return "$" + becommon.SanitizeIdent(v.LinkName), nil
+		}
+		return "$" + qbeSymbol(state, v.Path), nil
+	}
+	return "", fmt.Errorf("unsupported narrowed aggregate storage %T", value)
 }
 
 func lowerInterfaceDowncastPointer(state *moduleState, value mir.Value, target typeinfo.Type) ([]string, string, error) {

--- a/internal/backend/qbe/qbe.go
+++ b/internal/backend/qbe/qbe.go
@@ -2256,15 +2256,23 @@ func lowerAggregateCompositeAssign(state *moduleState, agg *aggregateLocal, comp
 		if !ok {
 			continue
 		}
-		op, err := qbeStoreOp(field.Type)
-		if err != nil {
-			return "", err
-		}
 		addr := qbeLocalName(agg.PtrName)
 		if field.Offset != 0 {
 			tmp := freshTemp(state, "addr")
 			lines = append(lines, fmt.Sprintf("%s =l add %s, %d", tmp, qbeLocalName(agg.PtrName), field.Offset))
 			addr = tmp
+		}
+		if isAggregateType(state, field.Type) {
+			valueLines, err := lowerAggregateValueToAddr(state, addr, field.Type, val)
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, valueLines...)
+			continue
+		}
+		op, err := qbeStoreOp(field.Type)
+		if err != nil {
+			return "", err
 		}
 		lowered, err := lowerValue(state, val)
 		if err != nil {
@@ -2407,19 +2415,35 @@ func lowerAggregateValueToAddr(state *moduleState, addr string, typ typeinfo.Typ
 }
 
 func lowerAggregateSource(state *moduleState, value mir.Value) (string, error) {
-	return backend.ResolveAggregateSource(
+	lines, src, err := backend.ResolveAggregateSource(
 		value,
-		func(v *mir.LocalValue) (string, error) { return lowerValue(state, v) },
-		func(v *mir.NameValue) (string, error) { return lowerValue(state, v) },
-		func(v mir.Value) (string, error) { return lowerValue(state, v) },
-		func(base mir.Value, fieldIndex int) (string, error) {
-			_, addr, _, err := lowerFieldAddress(state, base, fieldIndex)
+		func(v *mir.LocalValue) ([]string, string, error) {
+			src, err := lowerValue(state, v)
+			return nil, src, err
+		},
+		func(v *mir.NameValue) ([]string, string, error) {
+			src, err := lowerValue(state, v)
+			return nil, src, err
+		},
+		func(v mir.Value) ([]string, string, error) {
+			src, err := lowerValue(state, v)
+			return nil, src, err
+		},
+		func(base mir.Value, fieldIndex int) ([]string, string, error) {
+			lines, addr, _, err := lowerFieldAddress(state, base, fieldIndex)
 			if err != nil {
-				return "", err
+				return nil, "", err
 			}
-			return addr, nil
+			return lines, addr, nil
 		},
 	)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range lines {
+		state.pendingLines = append(state.pendingLines, line)
+	}
+	return src, nil
 }
 
 func lowerGlobalComposite(state *moduleState, typ typeinfo.Type, comp *mir.CompositeValue) (string, error) {
@@ -2479,6 +2503,15 @@ func lowerGlobalComposite(state *moduleState, typ typeinfo.Type, comp *mir.Compo
 		val, ok := items[field.Name]
 		if !ok {
 			parts = append(parts, fmt.Sprintf("z %d", field.Size))
+			offset += field.Size
+			continue
+		}
+		if isAggregateType(state, field.Type) {
+			body, err := lowerGlobalComposite(state, field.Type, val.(*mir.CompositeValue))
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, body)
 			offset += field.Size
 			continue
 		}
@@ -3512,6 +3545,15 @@ func qbeAggregateSubType(state *moduleState, typ typeinfo.Type) (string, error) 
 		}
 	}
 	if _, ok := typ.(*typeinfo.ErrorUnionType); ok {
+		return fmt.Sprintf("b %d", mustAggregateSize(state, typ)), nil
+	}
+	if _, ok := typ.(*typeinfo.StringType); ok {
+		return fmt.Sprintf("b %d", mustAggregateSize(state, typ)), nil
+	}
+	if _, ok := typ.(*typeinfo.SliceType); ok {
+		return fmt.Sprintf("b %d", mustAggregateSize(state, typ)), nil
+	}
+	if _, ok := backend.UnwrapNamed(typ).(*typeinfo.TupleType); ok {
 		return fmt.Sprintf("b %d", mustAggregateSize(state, typ)), nil
 	}
 	return qbeExtType(typ)

--- a/internal/backend/type_helpers_test.go
+++ b/internal/backend/type_helpers_test.go
@@ -176,4 +176,12 @@ func TestDescribeRuntimeTypeLayoutCapturesCompositePrintShape(t *testing.T) {
 	if tupleDesc.Fields[0].Offset != 0 || tupleDesc.Fields[1].Offset != 4 || tupleDesc.Fields[2].Offset != 8 {
 		t.Fatalf("unexpected tuple field offsets: %#v", tupleDesc.Fields)
 	}
+
+	optDesc, err := DescribeRuntimeTypeLayout(ctx, &typeinfo.OptionalType{Inner: &typeinfo.BuiltinType{Name: "i32"}})
+	if err != nil {
+		t.Fatalf("DescribeRuntimeTypeLayout(optional): %v", err)
+	}
+	if optDesc.Flags&RuntimeTypeFlagOptional == 0 || optDesc.Elem == nil || optDesc.PayloadOffset == 0 {
+		t.Fatalf("unexpected optional runtime descriptor: %#v", optDesc)
+	}
 }

--- a/internal/backend/typeinfo.go
+++ b/internal/backend/typeinfo.go
@@ -35,17 +35,19 @@ const (
 	RuntimeTypeFlagArray     = 1 << 6
 	RuntimeTypeFlagTuple     = 1 << 7
 	RuntimeTypeFlagVariants  = 1 << 8
+	RuntimeTypeFlagOptional  = 1 << 9
 )
 
 type RuntimeTypeDescriptor struct {
-	Name     string
-	ID       uint32
-	Flags    uint32
-	Elem     typeinfo.Type
-	Length   int64
-	Stride   int64
-	Fields   []RuntimeTypeFieldDescriptor
-	Variants []string
+	Name          string
+	ID            uint32
+	Flags         uint32
+	Elem          typeinfo.Type
+	Length        int64
+	Stride        int64
+	PayloadOffset int64
+	Fields        []RuntimeTypeFieldDescriptor
+	Variants      []string
 }
 
 type RuntimeTypeFieldDescriptor struct {
@@ -136,6 +138,8 @@ func DescribeRuntimeType(typ typeinfo.Type) RuntimeTypeDescriptor {
 		desc.Flags |= RuntimeTypeFlagInterface
 	case *typeinfo.SliceType:
 		desc.Flags |= RuntimeTypeFlagSlice
+	case *typeinfo.OptionalType:
+		desc.Flags |= RuntimeTypeFlagOptional
 	}
 	return desc
 }
@@ -171,6 +175,16 @@ func DescribeRuntimeTypeLayout(ctx AggregateLayoutContext, typ typeinfo.Type) (R
 				Offset: entry.Offset,
 				Type:   entry.Type,
 			})
+		}
+	case *typeinfo.OptionalType:
+		desc.Flags |= RuntimeTypeFlagOptional
+		desc.Elem = t.Inner
+		if !OptionalUsesNiche(t.Inner) {
+			info, err := TaggedUnionLayoutInfo(ctx, []typeinfo.Type{t.Inner})
+			if err != nil {
+				return desc, err
+			}
+			desc.PayloadOffset = info.PayloadOffset
 		}
 	}
 	return desc, nil

--- a/runtime/ferret_runtime.h
+++ b/runtime/ferret_runtime.h
@@ -90,6 +90,12 @@ typedef struct {
 #define FERRET_TYPE_FLAG_ARRAY     (1u << 6)
 #define FERRET_TYPE_FLAG_TUPLE     (1u << 7)
 #define FERRET_TYPE_FLAG_VARIANTS  (1u << 8)
+#define FERRET_TYPE_FLAG_OPTIONAL  (1u << 9)
+
+typedef struct {
+    const FerretTypeInfo *inner;
+    ferret_usize          payload_offset;
+} FerretOptionalTypeInfo;
 
 /* `FerretAny` (declared in ferrettypes.h) is the stable ABI type for empty
  * interface values across C helpers and runtime-adjacent extern functions. */

--- a/runtime/ferret_runtime_print.c
+++ b/runtime/ferret_runtime_print.c
@@ -98,6 +98,54 @@ static void ferret__write_big_integer(const void *data, const FerretTypeInfo *in
 
 static void ferret__write_typed(const void *data, const FerretTypeInfo *info);
 
+static ferret_bool ferret__optional_is_none(const void *data, const FerretTypeInfo *inner) {
+    ferret_u32 enum_like_none = 0xFFFFFFFFu;
+
+    if (data == NULL || inner == NULL) {
+        return 1;
+    }
+    if ((inner->flags & FERRET_TYPE_FLAG_POINTER) != 0u) {
+        return *(void *const *)data == NULL;
+    }
+    switch (inner->id) {
+    case FERRET_TYPE_BOOL:
+        return *(const ferret_u8 *)data == FERRET_OPT_BOOL_NONE;
+    case FERRET_TYPE_CHAR:
+        return *(const ferret_char *)data == FERRET_OPT_CHAR_NONE;
+    default:
+        break;
+    }
+    if ((inner->flags & FERRET_TYPE_FLAG_VARIANTS) != 0u && inner->size == sizeof(ferret_u32)) {
+        return *(const ferret_u32 *)data == enum_like_none;
+    }
+    return 0;
+}
+
+static void ferret__write_optional(const void *data, const FerretTypeInfo *info) {
+    const FerretOptionalTypeInfo *meta = (const FerretOptionalTypeInfo *)info->meta;
+    const ferret_u8 *base = (const ferret_u8 *)data;
+    const void *payload;
+
+    if (meta == NULL || meta->inner == NULL || base == NULL) {
+        fputs("none", stdout);
+        return;
+    }
+    if (meta->payload_offset != 0u) {
+        if (*(const ferret_u32 *)base == FERRET_NONE) {
+            fputs("none", stdout);
+            return;
+        }
+        payload = (const void *)(base + meta->payload_offset);
+        ferret__write_typed(payload, meta->inner);
+        return;
+    }
+    if (ferret__optional_is_none(data, meta->inner)) {
+        fputs("none", stdout);
+        return;
+    }
+    ferret__write_typed(data, meta->inner);
+}
+
 static void ferret__write_dynamic(const FerretAny *value) {
     if (value == NULL || (value->data == NULL && value->vtable == NULL)) {
         fputs("<any:nil>", stdout);
@@ -269,6 +317,10 @@ static void ferret__write_typed(const void *data, const FerretTypeInfo *info) {
     }
     if ((info->flags & FERRET_TYPE_FLAG_TUPLE) != 0u) {
         ferret__write_tuple(data, info);
+        return;
+    }
+    if ((info->flags & FERRET_TYPE_FLAG_OPTIONAL) != 0u) {
+        ferret__write_optional(data, info);
         return;
     }
     if ((info->flags & FERRET_TYPE_FLAG_POINTER) != 0u) {

--- a/tests/semma/optional_print.fer
+++ b/tests/semma/optional_print.fer
@@ -1,0 +1,15 @@
+fn main() -> void {
+    let some: ?i32 = 10
+    let empty: ?i32 = none
+
+    print(some)
+    print(empty)
+
+    if some != none {
+        print("optional-print-ok")
+        return
+    }
+
+    print("optional-print-fail")
+    exit(1)
+}

--- a/tests/semma/structs.fer
+++ b/tests/semma/structs.fer
@@ -1,0 +1,20 @@
+
+
+type User struct {
+    uid: i32 = 1,
+    name: str
+}
+
+fn main() {
+    let u = .User{ .name = "Fuad"}
+    print(u.name)
+
+    let value: ?i32 = 10
+    print(value)
+    if value != none {
+        print(value)
+    } else {
+        print("none")
+    }
+    print("done")
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for tagged optionals (optionals that are not represented as a simple "niche" value) in the backend, particularly for LLVM lowering and struct layout. It refactors how aggregate sources are resolved, adds new logic for handling tagged optionals in comparisons and assignments, and improves test coverage to ensure correctness. The changes also include several important bug fixes and enhancements to composite value lowering.

Key changes include:

### Tagged Optional Support

* Added full support for tagged optionals in struct layout and LLVM lowering, including correct field layout, pointer calculation, and runtime type info generation. Now, optionals that require a tag (i.e., cannot use a niche representation) are correctly handled throughout the backend. [[1]](diffhunk://#diff-32fffb9366139aea34bc7e0787911eb47298a23fed947705a1c421f06a44e73aR84-R128) [[2]](diffhunk://#diff-32fffb9366139aea34bc7e0787911eb47298a23fed947705a1c421f06a44e73aR163-R184) [[3]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R3246-R3265) [[4]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R3343-R3348) [[5]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R3360-R3381) [[6]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R3640-R3649) [[7]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R4922-R4948) [[8]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R1884-R1905) [[9]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50L3040-R3079) [[10]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50L3700-R3816) [[11]](diffhunk://#diff-d380305c4fe689059bbc57fa13a8342ba873e669baaa1a341f8e916469d053f3R1-R23)

* Implemented a new helper, `TaggedOptionalAgainstNone`, to detect and lower comparisons between tagged optionals and `none` values efficiently. [[1]](diffhunk://#diff-d380305c4fe689059bbc57fa13a8342ba873e669baaa1a341f8e916469d053f3R1-R23) [[2]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R1884-R1905)

### Aggregate Source Refactoring

* Refactored `ResolveAggregateSource` to allow callbacks to return both preparation lines and the source address, enabling more flexible lowering of field loads and aggregate accesses. Updated all call sites and tests accordingly. [[1]](diffhunk://#diff-4cd0fdbaf06a2a87d5ac9745ff0b15e319d1a5cc2cfa3cb57d424595ad48ac45L15-R19) [[2]](diffhunk://#diff-4cd0fdbaf06a2a87d5ac9745ff0b15e319d1a5cc2cfa3cb57d424595ad48ac45L42-R42) [[3]](diffhunk://#diff-b5964069a993b4735556422132a07a5cba5f72b5095169e89cfe89948c81e0ebL11-R17) [[4]](diffhunk://#diff-b5964069a993b4735556422132a07a5cba5f72b5095169e89cfe89948c81e0ebR26-R53) [[5]](diffhunk://#diff-b5964069a993b4735556422132a07a5cba5f72b5095169e89cfe89948c81e0ebL56-R79) [[6]](diffhunk://#diff-b5964069a993b4735556422132a07a5cba5f72b5095169e89cfe89948c81e0ebL79-R113) [[7]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50L3700-R3816)

### Composite and Aggregate Value Lowering

* Improved lowering of composite and aggregate values in LLVM, including recursive handling of aggregate fields and correct support for nested aggregates and tagged optionals in both global and local contexts. [[1]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50L3040-R3079) [[2]](diffhunk://#diff-6f09e34ecb33ec3bbf351822262b6c7fd3b9bffa58e97b9ab212420ec4ea1d50R4922-R4948)

### Testing and Validation

* Added new tests for tagged optional struct layouts and LLVM lowering, ensuring that tagged optionals are handled as expected and that common mistakes (like null pointer dereferences) are avoided. [[1]](diffhunk://#diff-a4b59869d006031027a383189cb5a4b49e409d2777683453557ae8521ef1b8daR71-R91) [[2]](diffhunk://#diff-ff671bd06a7924a7ce22798a922cd33ed3bff0d66a964347dc39a2dd7ed7d615R467-R546)

### Utilities and Helpers

* Added a utility function for scalar size/alignment in the shared backend, improving maintainability and correctness for primitive type layouts.

These changes collectively enable robust support for tagged optionals in the backend, improve code maintainability, and extend test coverage to prevent regressions.