### PR TITLE
Add LSP rename and adjust string literal typing

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -66,6 +66,7 @@ const (
 
 var (
 	identPattern        = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_]*$`)
+	identExactPattern   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 	memberPattern       = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)?$`)
 	staticMemberPattern = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*(?:<[^>\n]*>)?)::([A-Za-z_][A-Za-z0-9_]*)?$`)
 
@@ -168,6 +169,12 @@ type completionParams struct {
 	Position     lspPosition            `json:"position"`
 }
 
+type renameParams struct {
+	TextDocument textDocumentIdentifier `json:"textDocument"`
+	Position     lspPosition            `json:"position"`
+	NewName      string                 `json:"newName"`
+}
+
 type textDocumentIdentifier struct {
 	URI string `json:"uri"`
 }
@@ -227,6 +234,15 @@ type completionItem struct {
 	Kind          int    `json:"kind,omitempty"`
 	Detail        string `json:"detail,omitempty"`
 	Documentation string `json:"documentation,omitempty"`
+}
+
+type textEdit struct {
+	Range   lspRange `json:"range"`
+	NewText string   `json:"newText"`
+}
+
+type workspaceEdit struct {
+	Changes map[string][]textEdit `json:"changes,omitempty"`
 }
 
 type lspPosition struct {
@@ -385,6 +401,8 @@ func (s *Server) handleRequest(req rpcRequest) {
 		s.handleDefinition(req)
 	case "textDocument/completion":
 		s.handleCompletion(req)
+	case "textDocument/rename":
+		s.handleRename(req)
 	default:
 		if len(req.ID) > 0 {
 			s.writeError(req.ID, -32601, "method not found")
@@ -417,6 +435,7 @@ func (s *Server) handleInitialize(req rpcRequest) {
 			"completionProvider": map[string]any{
 				"triggerCharacters": []string{".", ":"},
 			},
+			"renameProvider": true,
 		},
 		"serverInfo": map[string]any{
 			"name":    "ferretls",
@@ -708,6 +727,327 @@ func (s *Server) handleCompletion(req rpcRequest) {
 	}
 	items := completionFromIndex(index, sourceText, pos)
 	s.writeResponse(req.ID, items)
+}
+
+func (s *Server) handleRename(req rpcRequest) {
+	if len(req.ID) == 0 {
+		return
+	}
+	params := renameParams{}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.writeError(req.ID, -32602, "invalid params")
+		return
+	}
+	if !isValidRenameIdentifier(params.NewName) {
+		s.writeError(req.ID, -32602, "newName must be a valid non-keyword identifier")
+		return
+	}
+	path, err := uriToPath(params.TextDocument.URI)
+	if err != nil || !isFerretSourcePath(path) {
+		s.writeResponse(req.ID, nil)
+		return
+	}
+
+	doc, hasDoc := s.documentState(params.TextDocument.URI)
+	sourceText := ""
+	hasOverlay := hasDoc && !doc.HasSyntaxErrors
+	if hasOverlay {
+		sourceText = doc.Text
+	}
+	result, parsedPath, cleanup := parseForProject(path, sourceText, hasOverlay, parseProject)
+	defer cleanup()
+
+	targetModule := findModuleByPath(result, parsedPath)
+	if targetModule == nil || targetModule.Bindings == nil {
+		s.writeResponse(req.ID, nil)
+		return
+	}
+	targetText := moduleSourceTextForRename(targetModule, parsedPath, path, sourceText, hasOverlay)
+	pos := source.Position{
+		Line:   params.Position.Line + 1,
+		Column: params.Position.Character + 1,
+	}
+	targetSymbol, owner := findRenameTargetSymbol(result, targetModule, targetText, pos)
+	if targetSymbol == nil || owner == nil || owner.Origin != context.ModuleOriginLocal {
+		s.writeResponse(req.ID, nil)
+		return
+	}
+
+	changes := collectWorkspaceRenameEdits(result, parsedPath, path, sourceText, hasOverlay, targetSymbol, params.NewName)
+	if len(changes) == 0 {
+		s.writeResponse(req.ID, nil)
+		return
+	}
+	s.writeResponse(req.ID, workspaceEdit{Changes: changes})
+}
+
+func isValidRenameIdentifier(name string) bool {
+	if !identExactPattern.MatchString(name) {
+		return false
+	}
+	return !tokens.IsKeyword(name)
+}
+
+func moduleSourceTextForRename(mod *context.Module, parsedPath, originalPath, overlayText string, hasOverlay bool) string {
+	if mod == nil {
+		return ""
+	}
+	if hasOverlay && sameFilePath(mod.FilePath, parsedPath) {
+		return overlayText
+	}
+	if mod.Content != "" {
+		return mod.Content
+	}
+	path := mod.FilePath
+	if sameFilePath(path, parsedPath) {
+		path = originalPath
+	}
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(bytes)
+}
+
+func findRenameTargetSymbol(result compiler.Result, mod *context.Module, sourceText string, pos source.Position) (*symbols.Symbol, *context.Module) {
+	if mod == nil || mod.Bindings == nil || len(mod.Bindings.Nodes) == 0 {
+		return nil, nil
+	}
+	modulesByKey := indexModulesByKey(result)
+	type candidate struct {
+		symbol *symbols.Symbol
+		owner  *context.Module
+		loc    source.Location
+	}
+	best := candidate{}
+	bestSpan := int(^uint(0) >> 1)
+	found := false
+	for node, res := range mod.Bindings.Nodes {
+		if res == nil || res.Kind != binding.ResolutionSymbol || res.Symbol == nil {
+			continue
+		}
+		locations := renameNodeLocations(node, res.Symbol.Name, sourceText, modulePathForNode(node, mod))
+		for _, loc := range locations {
+			if !locationContainsPosition(loc, pos) {
+				continue
+			}
+			span := locationSpan(loc)
+			if !found || span < bestSpan {
+				owner := modulesByKey[res.ModuleKey]
+				if owner == nil {
+					owner = findOwnerModuleForSymbol(result, res.Symbol)
+				}
+				if owner == nil {
+					owner = mod
+				}
+				best = candidate{symbol: res.Symbol, owner: owner, loc: loc}
+				bestSpan = span
+				found = true
+			}
+		}
+	}
+	if !found {
+		return nil, nil
+	}
+	return best.symbol, best.owner
+}
+
+func findOwnerModuleForSymbol(result compiler.Result, sym *symbols.Symbol) *context.Module {
+	if sym == nil {
+		return nil
+	}
+	candidates := make([]*context.Module, 0, len(result.Modules)+1)
+	if result.Entry != nil {
+		candidates = append(candidates, result.Entry)
+	}
+	candidates = append(candidates, result.Modules...)
+	for _, mod := range candidates {
+		if mod == nil || mod.ModuleScope == nil {
+			continue
+		}
+		for _, candidate := range mod.ModuleScope.Symbols() {
+			if candidate != nil && candidate.ID == sym.ID {
+				return mod
+			}
+		}
+	}
+	return nil
+}
+
+func collectWorkspaceRenameEdits(result compiler.Result, parsedPath, originalPath, overlayText string, hasOverlay bool, target *symbols.Symbol, newName string) map[string][]textEdit {
+	if target == nil || newName == "" {
+		return nil
+	}
+	modules := collectUniqueModules(result)
+	changes := make(map[string][]textEdit)
+	seenByURI := make(map[string]map[string]struct{})
+	for _, mod := range modules {
+		if mod == nil || mod.Origin != context.ModuleOriginLocal || mod.Bindings == nil {
+			continue
+		}
+		filePath := mod.FilePath
+		if sameFilePath(filePath, parsedPath) {
+			filePath = originalPath
+		}
+		uri, err := pathToURI(filePath)
+		if err != nil {
+			continue
+		}
+		sourceText := moduleSourceTextForRename(mod, parsedPath, originalPath, overlayText, hasOverlay)
+		if sourceText == "" {
+			continue
+		}
+		for node, res := range mod.Bindings.Nodes {
+			if res == nil || res.Kind != binding.ResolutionSymbol || res.Symbol == nil || res.Symbol.ID != target.ID {
+				continue
+			}
+			locations := renameNodeLocations(node, target.Name, sourceText, filePath)
+			for _, loc := range locations {
+				if loc.Start == nil {
+					continue
+				}
+				rng := locationToLSPRange(loc)
+				key := renameEditKey(rng)
+				if seenByURI[uri] == nil {
+					seenByURI[uri] = make(map[string]struct{})
+				}
+				if _, exists := seenByURI[uri][key]; exists {
+					continue
+				}
+				seenByURI[uri][key] = struct{}{}
+				changes[uri] = append(changes[uri], textEdit{
+					Range:   rng,
+					NewText: newName,
+				})
+			}
+		}
+	}
+	for uri := range changes {
+		sort.Slice(changes[uri], func(i, j int) bool {
+			a := changes[uri][i].Range
+			b := changes[uri][j].Range
+			if a.Start.Line != b.Start.Line {
+				return a.Start.Line < b.Start.Line
+			}
+			if a.Start.Character != b.Start.Character {
+				return a.Start.Character < b.Start.Character
+			}
+			if a.End.Line != b.End.Line {
+				return a.End.Line < b.End.Line
+			}
+			return a.End.Character < b.End.Character
+		})
+	}
+	if len(changes) == 0 {
+		return nil
+	}
+	return changes
+}
+
+func collectUniqueModules(result compiler.Result) []*context.Module {
+	seen := make(map[string]struct{})
+	out := make([]*context.Module, 0, len(result.Modules)+1)
+	add := func(mod *context.Module) {
+		if mod == nil {
+			return
+		}
+		key := mod.Key
+		if key == "" {
+			key = filepath.Clean(mod.FilePath)
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, mod)
+	}
+	add(result.Entry)
+	for _, mod := range result.Modules {
+		add(mod)
+	}
+	return out
+}
+
+func modulePathForNode(node ast.Node, mod *context.Module) string {
+	loc := source.Location{}
+	if node != nil {
+		loc = node.Loc()
+	}
+	if loc.File != "" {
+		return loc.File
+	}
+	if loc.Filename != nil && *loc.Filename != "" {
+		return *loc.Filename
+	}
+	if mod != nil {
+		return mod.FilePath
+	}
+	return ""
+}
+
+func renameEditKey(rng lspRange) string {
+	return fmt.Sprintf("%d:%d-%d:%d", rng.Start.Line, rng.Start.Character, rng.End.Line, rng.End.Character)
+}
+
+func renameNodeLocations(node ast.Node, symbolName, sourceText, file string) []source.Location {
+	if node == nil || symbolName == "" {
+		return nil
+	}
+	switch n := node.(type) {
+	case *ast.Ident:
+		if n == nil || len(n.Path) == 0 {
+			return nil
+		}
+		if len(n.Path) == 1 {
+			if n.Path[0] != symbolName {
+				return nil
+			}
+			return []source.Location{locationWithFile(n.Loc(), file)}
+		}
+		segments := identifierPathSegmentLocations(n, sourceText, file)
+		return matchingPathSegmentLocations(segments, n.Path, symbolName)
+	case *ast.NamedType:
+		if n == nil || len(n.Path) == 0 {
+			return nil
+		}
+		if len(n.Path) == 1 {
+			if n.Path[0] != symbolName {
+				return nil
+			}
+			return []source.Location{locationWithFile(n.Loc(), file)}
+		}
+		segments := namedTypePathSegmentLocations(n, sourceText, file)
+		return matchingPathSegmentLocations(segments, n.Path, symbolName)
+	default:
+		return nil
+	}
+}
+
+func locationWithFile(loc source.Location, file string) source.Location {
+	if file == "" {
+		return loc
+	}
+	loc.File = file
+	loc.Filename = &loc.File
+	return loc
+}
+
+func matchingPathSegmentLocations(segments []source.Location, path []string, symbolName string) []source.Location {
+	if len(segments) == 0 || len(segments) != len(path) {
+		return nil
+	}
+	matches := make([]source.Location, 0, len(path))
+	for i := range path {
+		if path[i] == symbolName {
+			matches = append(matches, segments[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	// For qualified paths, resolver resolutions target one segment. Prefer the
+	// rightmost name match to avoid editing aliases/import qualifiers.
+	return []source.Location{matches[len(matches)-1]}
 }
 
 func (s *Server) documentState(uri string) (openDocument, bool) {
@@ -2658,10 +2998,23 @@ func concreteOwnerTypeForPath(ident *ast.Ident, ownerSym *symbols.Symbol, ownerM
 }
 
 func identifierPathSegmentLocations(ident *ast.Ident, text, file string) []source.Location {
-	if ident == nil || len(ident.Path) == 0 || text == "" {
+	if ident == nil {
 		return nil
 	}
-	loc := ident.Loc()
+	return pathSegmentLocations(ident.Path, ident.Loc(), text, file)
+}
+
+func namedTypePathSegmentLocations(named *ast.NamedType, text, file string) []source.Location {
+	if named == nil {
+		return nil
+	}
+	return pathSegmentLocations(named.Path, named.Loc(), text, file)
+}
+
+func pathSegmentLocations(path []string, loc source.Location, text, file string) []source.Location {
+	if len(path) == 0 || text == "" {
+		return nil
+	}
 	if loc.Start == nil || loc.End == nil {
 		return nil
 	}
@@ -2673,8 +3026,8 @@ func identifierPathSegmentLocations(ident *ast.Ident, text, file string) []sourc
 	snippet := text[start:end]
 	pos := *loc.Start
 	cursor := 0
-	out := make([]source.Location, 0, len(ident.Path))
-	for _, segment := range ident.Path {
+	out := make([]source.Location, 0, len(path))
+	for _, segment := range path {
 		if segment == "" {
 			return nil
 		}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -927,15 +927,15 @@ func collectWorkspaceRenameEdits(result compiler.Result, parsedPath, originalPat
 			a := changes[uri][i].Range
 			b := changes[uri][j].Range
 			if a.Start.Line != b.Start.Line {
-				return a.Start.Line < b.Start.Line
+				return a.Start.Line > b.Start.Line
 			}
 			if a.Start.Character != b.Start.Character {
-				return a.Start.Character < b.Start.Character
+				return a.Start.Character > b.Start.Character
 			}
 			if a.End.Line != b.End.Line {
-				return a.End.Line < b.End.Line
+				return a.End.Line > b.End.Line
 			}
-			return a.End.Character < b.End.Character
+			return a.End.Character > b.End.Character
 		})
 	}
 	if len(changes) == 0 {
@@ -1028,7 +1028,8 @@ func locationWithFile(loc source.Location, file string) source.Location {
 		return loc
 	}
 	loc.File = file
-	loc.Filename = &loc.File
+	filename := loc.File
+	loc.Filename = &filename
 	return loc
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -174,8 +174,162 @@ func TestInitializeAdvertisesHoverDefinitionAndCompletionProvider(t *testing.T) 
 		t.Fatal("expected completion trigger characters")
 	}
 
+	var renameProvider bool
+	if err := json.Unmarshal(payload.Capabilities["renameProvider"], &renameProvider); err != nil {
+		t.Fatalf("failed to decode renameProvider: %v", err)
+	}
+	if !renameProvider {
+		t.Fatal("expected renameProvider=true")
+	}
+
 	if _, ok := payload.Capabilities["documentSymbolProvider"]; ok {
 		t.Fatal("expected documentSymbolProvider to be omitted")
+	}
+}
+
+func TestRenameReturnsWorkspaceEditsAcrossLocalModules(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.fer")
+	utilPath := filepath.Join(dir, "util", "math.fer")
+	if err := os.MkdirAll(filepath.Dir(utilPath), 0o755); err != nil {
+		t.Fatalf("mkdir util dir: %v", err)
+	}
+	mainSrc := "import \"util/math\"\n\nfn main() -> i32 {\n    return math::Value(2)\n}\n"
+	utilSrc := "fn Value(v: i32) -> i32 {\n    return v\n}\n\nfn Use() -> i32 {\n    return Value(1)\n}\n"
+	if err := os.WriteFile(mainPath, []byte(mainSrc), 0o644); err != nil {
+		t.Fatalf("write main source: %v", err)
+	}
+	if err := os.WriteFile(utilPath, []byte(utilSrc), 0o644); err != nil {
+		t.Fatalf("write util source: %v", err)
+	}
+
+	line, char, ok := findPosition(mainSrc, "math::Value")
+	if !ok {
+		t.Fatal("failed to find Value call position")
+	}
+	char += len("math::")
+
+	var out bytes.Buffer
+	uri := "file://" + filepath.ToSlash(mainPath)
+	s := &Server{out: &out, documents: make(map[string]openDocument)}
+	s.handleRequest(rpcRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "textDocument/rename",
+		Params: mustRawJSON(t, renameParams{
+			TextDocument: textDocumentIdentifier{URI: uri},
+			Position:     lspPosition{Line: line, Character: char},
+			NewName:      "RenamedValue",
+		}),
+	})
+
+	edit := decodeWorkspaceEditResult(t, out.String())
+	if edit == nil || len(edit.Changes) == 0 {
+		t.Fatalf("expected workspace rename edits, got %#v", edit)
+	}
+	mainURI := "file://" + filepath.ToSlash(mainPath)
+	utilURI := "file://" + filepath.ToSlash(utilPath)
+	if len(edit.Changes[mainURI]) != 1 {
+		t.Fatalf("expected 1 edit in main file, got %#v", edit.Changes[mainURI])
+	}
+	if len(edit.Changes[utilURI]) != 2 {
+		t.Fatalf("expected 2 edits in util file, got %#v", edit.Changes[utilURI])
+	}
+}
+
+func TestRenameRejectsInvalidNewName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.fer")
+	src := "fn run2() -> void {}\nfn main() { run2() }\n"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	line, char, ok := findPosition(src, "run2()")
+	if !ok {
+		t.Fatal("failed to find run2 call")
+	}
+
+	var out bytes.Buffer
+	uri := "file://" + filepath.ToSlash(path)
+	s := &Server{out: &out, documents: make(map[string]openDocument)}
+	s.handleRequest(rpcRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "textDocument/rename",
+		Params: mustRawJSON(t, renameParams{
+			TextDocument: textDocumentIdentifier{URI: uri},
+			Position:     lspPosition{Line: line, Character: char},
+			NewName:      "1bad",
+		}),
+	})
+	resp := decodeSingleResponse(t, out.String())
+	if resp.Error == nil {
+		t.Fatal("expected rename invalid-identifier error")
+	}
+	if resp.Error.Code != -32602 {
+		t.Fatalf("expected invalid params error, got %#v", resp.Error)
+	}
+}
+
+func TestRenameDoesNotRenameDependencyOwnedSymbol(t *testing.T) {
+	parent := t.TempDir()
+	appRoot := filepath.Join(parent, "app")
+	depRoot := filepath.Join(parent, "dep")
+	if err := os.MkdirAll(appRoot, 0o755); err != nil {
+		t.Fatalf("mkdir app root: %v", err)
+	}
+	if err := os.MkdirAll(depRoot, 0o755); err != nil {
+		t.Fatalf("mkdir dep root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(depRoot, "fer.ret"), []byte("[package]\nname = \"dep\"\n"), 0o644); err != nil {
+		t.Fatalf("write dep manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(depRoot, "api.fer"), []byte("fn Value() -> i32 {\n    return 1\n}\n"), 0o644); err != nil {
+		t.Fatalf("write dep source: %v", err)
+	}
+	manifestSrc := "[package]\nname = \"app\"\n\n[dependencies]\ntool = \"../dep\"\n"
+	if err := os.WriteFile(filepath.Join(appRoot, "fer.ret"), []byte(manifestSrc), 0o644); err != nil {
+		t.Fatalf("write app manifest: %v", err)
+	}
+	mainSrc := "import \"tool/api\"\n\nfn main() -> i32 {\n    return api::Value()\n}\n"
+	mainPath := filepath.Join(appRoot, "main.fer")
+	if err := os.WriteFile(mainPath, []byte(mainSrc), 0o644); err != nil {
+		t.Fatalf("write app source: %v", err)
+	}
+	line, char, ok := findPosition(mainSrc, "api::Value")
+	if !ok {
+		t.Fatal("failed to find dependency call")
+	}
+	char += len("api::")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(appRoot); err != nil {
+		t.Fatalf("chdir app root: %v", err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+
+	var out bytes.Buffer
+	uri := "file://" + filepath.ToSlash(mainPath)
+	s := &Server{out: &out, documents: make(map[string]openDocument)}
+	s.handleRequest(rpcRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "textDocument/rename",
+		Params: mustRawJSON(t, renameParams{
+			TextDocument: textDocumentIdentifier{URI: uri},
+			Position:     lspPosition{Line: line, Character: char},
+			NewName:      "RenamedValue",
+		}),
+	})
+	resp := decodeSingleResponse(t, out.String())
+	if resp.Error != nil {
+		t.Fatalf("unexpected rename response error: %#v", resp.Error)
+	}
+	if resp.Result != nil {
+		t.Fatalf("expected nil workspace edit for dependency-owned symbol, got %#v", resp.Result)
 	}
 }
 
@@ -3870,6 +4024,26 @@ func decodeCompletionResult(t *testing.T, framed string) []completionItem {
 		t.Fatalf("failed to unmarshal completion result: %v", err)
 	}
 	return items
+}
+
+func decodeWorkspaceEditResult(t *testing.T, framed string) *workspaceEdit {
+	t.Helper()
+	resp := decodeSingleResponse(t, framed)
+	if resp.Error != nil {
+		t.Fatalf("unexpected rename error: %#v", resp.Error)
+	}
+	if resp.Result == nil {
+		return nil
+	}
+	raw, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("failed to marshal workspace edit result: %v", err)
+	}
+	var edit workspaceEdit
+	if err := json.Unmarshal(raw, &edit); err != nil {
+		t.Fatalf("failed to unmarshal workspace edit result: %v", err)
+	}
+	return &edit
 }
 
 func decodeFramedBodies(t *testing.T, framed string) [][]byte {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -210,7 +210,7 @@ func TestRenameReturnsWorkspaceEditsAcrossLocalModules(t *testing.T) {
 	char += len("math::")
 
 	var out bytes.Buffer
-	uri := "file://" + filepath.ToSlash(mainPath)
+	uri := mustPathToURI(t, mainPath)
 	s := &Server{out: &out, documents: make(map[string]openDocument)}
 	s.handleRequest(rpcRequest{
 		JSONRPC: "2.0",
@@ -227,8 +227,8 @@ func TestRenameReturnsWorkspaceEditsAcrossLocalModules(t *testing.T) {
 	if edit == nil || len(edit.Changes) == 0 {
 		t.Fatalf("expected workspace rename edits, got %#v", edit)
 	}
-	mainURI := "file://" + filepath.ToSlash(mainPath)
-	utilURI := "file://" + filepath.ToSlash(utilPath)
+	mainURI := mustPathToURI(t, mainPath)
+	utilURI := mustPathToURI(t, utilPath)
 	if len(edit.Changes[mainURI]) != 1 {
 		t.Fatalf("expected 1 edit in main file, got %#v", edit.Changes[mainURI])
 	}
@@ -250,7 +250,7 @@ func TestRenameRejectsInvalidNewName(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	uri := "file://" + filepath.ToSlash(path)
+	uri := mustPathToURI(t, path)
 	s := &Server{out: &out, documents: make(map[string]openDocument)}
 	s.handleRequest(rpcRequest{
 		JSONRPC: "2.0",
@@ -312,7 +312,7 @@ func TestRenameDoesNotRenameDependencyOwnedSymbol(t *testing.T) {
 	defer func() { _ = os.Chdir(cwd) }()
 
 	var out bytes.Buffer
-	uri := "file://" + filepath.ToSlash(mainPath)
+	uri := mustPathToURI(t, mainPath)
 	s := &Server{out: &out, documents: make(map[string]openDocument)}
 	s.handleRequest(rpcRequest{
 		JSONRPC: "2.0",
@@ -4044,6 +4044,15 @@ func decodeWorkspaceEditResult(t *testing.T, framed string) *workspaceEdit {
 		t.Fatalf("failed to unmarshal workspace edit result: %v", err)
 	}
 	return &edit
+}
+
+func mustPathToURI(t *testing.T, path string) string {
+	t.Helper()
+	uri, err := pathToURI(path)
+	if err != nil {
+		t.Fatalf("pathToURI(%q): %v", path, err)
+	}
+	return uri
 }
 
 func decodeFramedBodies(t *testing.T, framed string) [][]byte {


### PR DESCRIPTION
This pull request adds support for the Language Server Protocol (LSP) "rename" feature to the server, enabling users to perform symbol renaming across multiple files in a project. The implementation includes server-side logic, new data structures, and comprehensive tests to ensure correct behavior, including validation and edge cases.

**LSP Rename Feature Implementation:**

* Added support for the `"textDocument/rename"` LSP request, including the main handler `handleRename`, which locates the symbol at the given position, validates the new name, and returns a `workspaceEdit` with all required text edits across local modules. [[1]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8R404-R405) [[2]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8R732-R1052)
* Introduced new types: `renameParams`, `textEdit`, and `workspaceEdit` to represent the parameters and results for rename operations. [[1]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8R172-R177) [[2]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8R239-R247)
* Advertised `"renameProvider": true` in the server's initialization capabilities, allowing LSP clients to detect support for rename.
* Added a stricter identifier validation regex (`identExactPattern`) and supporting logic to ensure only valid, non-keyword identifiers can be used as new names. [[1]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8R69) [[2]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8R732-R1052)

**Symbol and Source Location Utilities:**

* Refactored and extended utility functions to accurately locate and match symbol path segments in source text, supporting both identifiers and named types. This improves the precision of rename operations. [[1]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8L2661-L2664) [[2]](diffhunk://#diff-0077cc8440363b2137f8e3e405549e59083242b4281d50b08702a6b7153492a8L2676-R3030)

**Comprehensive Testing:**

* Added tests to verify that rename operations:
  - Return correct workspace edits affecting all relevant files.
  - Reject invalid new names (e.g., not a valid identifier).
  - Do not allow renaming symbols owned by dependencies.
  - Advertise the rename capability during initialization.
* Added a test helper to decode and validate `workspaceEdit` results.

Fixed #42 