### PR TITLE
Closure

### DIFF
--- a/internal/analysis/cfg/analysis/liveness.go
+++ b/internal/analysis/cfg/analysis/liveness.go
@@ -210,6 +210,10 @@ func accumulateExprUses(use, def, locals cfg.LocalSet, expr hir.Expr) {
 		for _, arg := range e.Args {
 			accumulateExprUses(use, def, locals, arg)
 		}
+	case *hir.ClosureLit:
+		for _, capture := range e.Captures {
+			accumulateExprUses(use, def, locals, capture)
+		}
 	case *hir.SelectorExpr:
 		accumulateExprUses(use, def, locals, e.Left)
 	case *hir.CastExpr:

--- a/internal/analysis/semantics/ownership/multi_borrow_test.go
+++ b/internal/analysis/semantics/ownership/multi_borrow_test.go
@@ -1,0 +1,54 @@
+package ownership
+
+import (
+	"testing"
+
+	"compiler/internal/analysis/semantics/typeinfo"
+	corectx "compiler/internal/core/context"
+	"compiler/internal/core/diagnostics"
+	"compiler/internal/ir/mir"
+)
+
+func TestBindBorrowValueRejectsConflictingPlannedBorrows(t *testing.T) {
+	ctx := corectx.New(".", ".fer", diagnostics.NewDiagnosticBag(""))
+	a := &ownershipAnalyzer{
+		ctx:      ctx,
+		reported: make(map[string]struct{}),
+		currentFn: &mir.Function{
+			Locals: []*mir.Local{
+				{ID: 0, Name: "x", Type: &typeinfo.BuiltinType{Name: "i32"}, Mutable: true},
+				{ID: 1, Name: "tmp", Type: typeinfo.UnknownType{}},
+			},
+		},
+	}
+	scope := newValueScope()
+	scope.Declare(0, valueInfo{typ: &typeinfo.BuiltinType{Name: "i32"}, mutable: true})
+	slot := scope.Declare(1, valueInfo{typ: typeinfo.UnknownType{}})
+	value := &mir.CompositeValue{
+		Items: []mir.CompositeItem{
+			{
+				Value: &mir.AddrOfValue{
+					Source: &mir.LocalValue{LocalID: 0},
+				},
+			},
+			{
+				Value: &mir.AddrOfValue{
+					Source:  &mir.LocalValue{LocalID: 0},
+					Mutable: true,
+				},
+			},
+		},
+	}
+
+	a.bindBorrowValue(scope, slot, value)
+
+	if len(slot.borrows) != 0 {
+		t.Fatalf("expected conflicting planned borrows to be rejected, got %#v", slot.borrows)
+	}
+	for _, diag := range ctx.Diagnostics.Diagnostics() {
+		if diag.Code == diagnostics.ErrBorrowConflict {
+			return
+		}
+	}
+	t.Fatalf("expected %s diagnostic, got %#v", diagnostics.ErrBorrowConflict, ctx.Diagnostics.Diagnostics())
+}

--- a/internal/analysis/semantics/ownership/ownership.go
+++ b/internal/analysis/semantics/ownership/ownership.go
@@ -996,6 +996,8 @@ func (a *ownershipAnalyzer) bindBorrowValue(scope *valueScope, slot *valueInfo, 
 		return
 	}
 	// Validate first to avoid partial freeze updates.
+	plannedImm := make(map[int]source.Location, len(borrows))
+	plannedMut := make(map[int]source.Location, len(borrows))
 	for _, info := range borrows {
 		if !info.owner.isLocal() {
 			continue
@@ -1009,9 +1011,24 @@ func (a *ownershipAnalyzer) bindBorrowValue(scope *valueScope, slot *valueInfo, 
 				a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create mutable borrow while another borrow is live")
 				return
 			}
+			if _, ok := plannedImm[info.owner.localID]; ok {
+				a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create mutable borrow while another borrow is planned")
+				return
+			}
+			if _, ok := plannedMut[info.owner.localID]; ok {
+				a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create mutable borrow while another borrow is planned")
+				return
+			}
+			plannedMut[info.owner.localID] = info.loc
 		} else if owner.mutFrozen > 0 {
 			a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create immutable borrow while a mutable borrow is live")
 			return
+		} else {
+			if _, ok := plannedMut[info.owner.localID]; ok {
+				a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create immutable borrow while a mutable borrow is planned")
+				return
+			}
+			plannedImm[info.owner.localID] = info.loc
 		}
 	}
 

--- a/internal/analysis/semantics/ownership/ownership.go
+++ b/internal/analysis/semantics/ownership/ownership.go
@@ -270,7 +270,7 @@ func (a *ownershipAnalyzer) releaseDeadBorrows(scope *valueScope, keep cfg.Local
 		return
 	}
 	for id, slot := range scope.values {
-		if slot == nil || slot.borrowOf < 0 {
+		if slot == nil || len(slot.borrows) == 0 {
 			continue
 		}
 		if keep.Has(id) || a.deferUses.Has(id) {
@@ -691,7 +691,7 @@ func (a *ownershipAnalyzer) checkAddrOfValue(scope *valueScope, value *mir.AddrO
 		}
 		return
 	}
-	if owner.mutBorrow {
+	if owner.mutFrozen > 0 {
 		a.reportBorrowConflict(value.Loc(), root.localID, "cannot create immutable borrow while a mutable borrow is live")
 	}
 }
@@ -991,45 +991,84 @@ func (a *ownershipAnalyzer) bindBorrowValue(scope *valueScope, slot *valueInfo, 
 	if value == nil {
 		return
 	}
-	info, ok := a.borrowValueInfo(scope, value)
-	if !ok || !info.owner.isLocal() {
+	borrows, ok := a.borrowValueInfos(scope, value)
+	if !ok || len(borrows) == 0 {
 		return
 	}
-	owner, _ := scope.Lookup(info.owner.localID)
-	if owner == nil {
-		return
-	}
-	if info.mutable {
-		if owner.frozen > 0 {
-			a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create mutable borrow while another borrow is live")
+	// Validate first to avoid partial freeze updates.
+	for _, info := range borrows {
+		if !info.owner.isLocal() {
+			continue
+		}
+		owner, _ := scope.Lookup(info.owner.localID)
+		if owner == nil {
+			continue
+		}
+		if info.mutable {
+			if owner.frozen > 0 {
+				a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create mutable borrow while another borrow is live")
+				return
+			}
+		} else if owner.mutFrozen > 0 {
+			a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create immutable borrow while a mutable borrow is live")
 			return
 		}
-	} else if owner.mutBorrow {
-		a.reportBorrowConflict(info.loc, info.owner.localID, "cannot create immutable borrow while a mutable borrow is live")
-		return
 	}
-	slot.borrowOf = info.owner.localID
-	slot.borrowMut = info.mutable
-	slot.borrowLoc = info.loc
-	owner.frozen++
-	if info.mutable {
-		owner.mutBorrow = true
+
+	// Stable ordering + de-dupe for deterministic state merges.
+	slices.SortFunc(borrows, func(a, b borrowInfo) int {
+		if a.owner.localID < b.owner.localID {
+			return -1
+		}
+		if a.owner.localID > b.owner.localID {
+			return 1
+		}
+		if !a.mutable && b.mutable {
+			return -1
+		}
+		if a.mutable && !b.mutable {
+			return 1
+		}
+		return 0
+	})
+	uniq := borrows[:0]
+	var lastOwner int = -1
+	var lastMut bool
+	for _, info := range borrows {
+		if !info.owner.isLocal() {
+			continue
+		}
+		if info.owner.localID == lastOwner && info.mutable == lastMut {
+			continue
+		}
+		lastOwner = info.owner.localID
+		lastMut = info.mutable
+		uniq = append(uniq, info)
+	}
+	borrows = uniq
+
+	slot.borrows = make([]borrowSlot, 0, len(borrows))
+	for _, info := range borrows {
+		if !info.owner.isLocal() {
+			continue
+		}
+		owner, _ := scope.Lookup(info.owner.localID)
+		if owner == nil {
+			continue
+		}
+		owner.frozen++
+		if info.mutable {
+			owner.mutFrozen++
+		}
+		slot.borrows = append(slot.borrows, borrowSlot{owner: info.owner.localID, mutable: info.mutable, loc: info.loc})
 	}
 }
 
 func (a *ownershipAnalyzer) releaseBorrowValue(scope *valueScope, slot *valueInfo) {
-	if scope == nil || slot == nil || slot.borrowOf < 0 {
+	if scope == nil || slot == nil || len(slot.borrows) == 0 {
 		return
 	}
-	if owner, ok := scope.Lookup(slot.borrowOf); ok && owner != nil && owner.frozen > 0 {
-		owner.frozen--
-		if slot.borrowMut && owner.frozen == 0 {
-			owner.mutBorrow = false
-		}
-	}
-	slot.borrowOf = -1
-	slot.borrowMut = false
-	slot.borrowLoc = source.Location{}
+	releaseBorrows(scope, slot)
 }
 
 func (a *ownershipAnalyzer) rebindBorrowAssignment(scope *valueScope, left mir.Place, right mir.Value) {
@@ -1209,7 +1248,7 @@ func (a *ownershipAnalyzer) requireActivePath(scope *valueScope, root int, path 
 		a.reportMovedPathUse(root, path, loc, info.moveLoc, info.movedPath)
 		return
 	}
-	if info.mutBorrow || a.hasActiveMutableBorrowOf(scope, root) {
+	if a.hasActiveMutableBorrowOf(scope, root) {
 		a.reportBorrowConflict(loc, root, "cannot use value while a mutable borrow is live")
 		return
 	}
@@ -1228,15 +1267,8 @@ func (a *ownershipAnalyzer) hasActiveMutableBorrowOf(scope *valueScope, root int
 	if scope == nil || root < 0 {
 		return false
 	}
-	for _, slot := range scope.values {
-		if slot == nil {
-			continue
-		}
-		if slot.borrowOf == root && slot.borrowMut {
-			return true
-		}
-	}
-	return false
+	slot, _ := scope.Lookup(root)
+	return slot != nil && slot.mutFrozen > 0
 }
 
 func (a *ownershipAnalyzer) reportPartialMoveUse(root int, loc source.Location, info *valueInfo) {
@@ -1383,40 +1415,81 @@ func (a *ownershipAnalyzer) reportBorrowEscapeIfNeeded(scope *valueScope, value 
 }
 
 func (a *ownershipAnalyzer) borrowValueInfo(scope *valueScope, value mir.Value) (borrowInfo, bool) {
-	if value == nil {
+	infos, ok := a.borrowValueInfos(scope, value)
+	if !ok || len(infos) == 0 {
 		return borrowInfo{}, false
+	}
+	return infos[0], true
+}
+
+func (a *ownershipAnalyzer) borrowValueInfos(scope *valueScope, value mir.Value) ([]borrowInfo, bool) {
+	if value == nil {
+		return nil, false
 	}
 	switch v := value.(type) {
 	case *mir.LocalValue:
 		if info, ok := a.temps[v.LocalID]; ok && info.borrow != nil {
-			return *info.borrow, true
+			return []borrowInfo{*info.borrow}, true
 		}
 		if scope != nil {
-			if slot, _ := scope.Lookup(v.LocalID); slot != nil && slot.borrowOf >= 0 {
-				return borrowInfo{owner: ownerLocal(slot.borrowOf), loc: slot.borrowLoc, mutable: slot.borrowMut}, true
+			if slot, _ := scope.Lookup(v.LocalID); slot != nil && len(slot.borrows) > 0 {
+				out := make([]borrowInfo, 0, len(slot.borrows))
+				for _, b := range slot.borrows {
+					if b.owner < 0 {
+						continue
+					}
+					out = append(out, borrowInfo{owner: ownerLocal(b.owner), loc: b.loc, mutable: b.mutable})
+				}
+				if len(out) > 0 {
+					return out, true
+				}
 			}
 		}
 	case *mir.AddrOfValue:
 		if v.Raw {
-			return borrowInfo{}, false
+			return nil, false
 		}
 		root, _, ok := a.borrowSourcePath(v.Source)
 		if !ok {
-			return borrowInfo{}, false
+			return nil, false
 		}
-		return borrowInfo{owner: root, loc: v.Loc(), mutable: v.Mutable}, true
+		return []borrowInfo{{owner: root, loc: v.Loc(), mutable: v.Mutable}}, true
 	case *mir.UnaryValue:
 		if v.Op == "&" || v.Op == "&mut" {
 			root, _, ok := a.borrowSourcePath(v.Right)
 			if !ok {
-				return borrowInfo{}, false
+				return nil, false
 			}
-			return borrowInfo{owner: root, loc: v.Loc(), mutable: v.Op == "&mut"}, true
+			return []borrowInfo{{owner: root, loc: v.Loc(), mutable: v.Op == "&mut"}}, true
+		}
+	case *mir.ClosureValue:
+		var out []borrowInfo
+		for _, cap := range v.Captures {
+			infos, ok := a.borrowValueInfos(scope, cap)
+			if !ok || len(infos) == 0 {
+				continue
+			}
+			out = append(out, infos...)
+		}
+		if len(out) > 0 {
+			return out, true
+		}
+	case *mir.CompositeValue:
+		var out []borrowInfo
+		for _, item := range v.Items {
+			infos, ok := a.borrowValueInfos(scope, item.Value)
+			if !ok || len(infos) == 0 {
+				continue
+			}
+			out = append(out, infos...)
+		}
+		if len(out) > 0 {
+			return out, true
 		}
 	case *mir.InterfaceValue:
-		return a.borrowValueInfo(scope, v.Value)
+		return a.borrowValueInfos(scope, v.Value)
 	}
-	return borrowInfo{}, false
+	return nil, false
 }
 
 func (a *ownershipAnalyzer) reportBorrowConflict(loc source.Location, localID int, message string) {

--- a/internal/analysis/semantics/ownership/state.go
+++ b/internal/analysis/semantics/ownership/state.go
@@ -17,14 +17,18 @@ type valueInfo struct {
 	movedPath string
 	movedSubs map[string]source.Location
 	frozen    int
-	mutBorrow bool
-	borrowOf  int
-	borrowMut bool
-	borrowLoc source.Location
+	mutFrozen int
+	borrows   []borrowSlot
 }
 
 type valueScope struct {
 	values map[int]*valueInfo
+}
+
+type borrowSlot struct {
+	owner   int
+	mutable bool
+	loc     source.Location
 }
 
 func newValueScope() *valueScope {
@@ -40,7 +44,6 @@ func (s *valueScope) Declare(id int, info valueInfo) *valueInfo {
 		concrete: info.concrete,
 		mutable:  info.mutable,
 		constant: info.constant,
-		borrowOf: -1,
 	}
 	if len(info.movedSubs) > 0 {
 		slot.movedSubs = cloneMovedSubs(info.movedSubs)
@@ -83,20 +86,14 @@ func (s *valueScope) TrimToLiveOut(live cfg.LocalSet) {
 		if info == nil || live.Has(id) {
 			continue
 		}
-		if info.borrowOf >= 0 {
-			if owner, ok := s.values[info.borrowOf]; ok && owner != nil && owner.frozen > 0 {
-				owner.frozen--
-			}
-		}
+		releaseBorrows(s, info)
 		info.moved = false
 		info.moveLoc = source.Location{}
 		info.movedPath = ""
 		info.movedSubs = nil
 		info.frozen = 0
-		info.mutBorrow = false
-		info.borrowOf = -1
-		info.borrowMut = false
-		info.borrowLoc = source.Location{}
+		info.mutFrozen = 0
+		info.borrows = nil
 	}
 }
 
@@ -138,10 +135,8 @@ func equalValueInfo(a, b *valueInfo) bool {
 		a.movedPath == b.movedPath &&
 		equalMovedSubs(a.movedSubs, b.movedSubs) &&
 		a.frozen == b.frozen &&
-		a.mutBorrow == b.mutBorrow &&
-		a.borrowOf == b.borrowOf &&
-		a.borrowMut == b.borrowMut &&
-		a.borrowLoc == b.borrowLoc
+		a.mutFrozen == b.mutFrozen &&
+		equalBorrowSlots(a.borrows, b.borrows)
 }
 
 func mergeValueInfo(a, b *valueInfo) *valueInfo {
@@ -178,19 +173,13 @@ func mergeValueInfo(a, b *valueInfo) *valueInfo {
 	if b.frozen > out.frozen {
 		out.frozen = b.frozen
 	}
-	out.mutBorrow = a.mutBorrow || b.mutBorrow
-	if a.borrowOf == b.borrowOf {
-		out.borrowOf = a.borrowOf
-		out.borrowMut = a.borrowMut || b.borrowMut
-		if a.borrowLoc.Start != nil {
-			out.borrowLoc = a.borrowLoc
-		} else {
-			out.borrowLoc = b.borrowLoc
-		}
+	if b.mutFrozen > out.mutFrozen {
+		out.mutFrozen = b.mutFrozen
+	}
+	if equalBorrowSlots(a.borrows, b.borrows) {
+		out.borrows = cloneBorrowSlots(a.borrows)
 	} else {
-		out.borrowOf = -1
-		out.borrowMut = false
-		out.borrowLoc = source.Location{}
+		out.borrows = nil
 	}
 	return &out
 }
@@ -216,6 +205,49 @@ func equalMovedSubs(a, b map[string]source.Location) bool {
 		}
 	}
 	return true
+}
+
+func equalBorrowSlots(a, b []borrowSlot) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].owner != b[i].owner || a[i].mutable != b[i].mutable || a[i].loc != b[i].loc {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneBorrowSlots(in []borrowSlot) []borrowSlot {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]borrowSlot, len(in))
+	copy(out, in)
+	return out
+}
+
+func releaseBorrows(scope *valueScope, info *valueInfo) {
+	if scope == nil || info == nil || len(info.borrows) == 0 {
+		return
+	}
+	for _, b := range info.borrows {
+		if b.owner < 0 {
+			continue
+		}
+		owner, ok := scope.values[b.owner]
+		if !ok || owner == nil {
+			continue
+		}
+		if owner.frozen > 0 {
+			owner.frozen--
+		}
+		if b.mutable && owner.mutFrozen > 0 {
+			owner.mutFrozen--
+		}
+	}
+	info.borrows = nil
 }
 
 func mergeMovedSubs(a, b map[string]source.Location) map[string]source.Location {

--- a/internal/analysis/semantics/typechecker/core.go
+++ b/internal/analysis/semantics/typechecker/core.go
@@ -84,7 +84,6 @@ type checker struct {
 	currentGenericFunc         *symbols.Symbol
 	currentGenericRequirements []*typeinfo.GenericRequirement
 	lambdaScopes               []*lambdaScope
-	allowCapturedLambdaValue   int
 }
 
 func (c *checker) pushTypeParams(mod *context.Module, owner ast.Node, params []ast.TypeParam) []*typeinfo.TypeParam {

--- a/internal/analysis/semantics/typechecker/core.go
+++ b/internal/analysis/semantics/typechecker/core.go
@@ -22,9 +22,10 @@ type refineScope struct {
 }
 
 type lambdaScope struct {
-	owned    map[symbols.SymbolID]struct{}
-	captures map[symbols.SymbolID]*symbols.Symbol
-	move     bool
+	owned      map[symbols.SymbolID]struct{}
+	captures   map[symbols.SymbolID]*symbols.Symbol
+	captureMut map[symbols.SymbolID]struct{}
+	move       bool
 }
 
 func newRefineScope(parent *refineScope) *refineScope {
@@ -137,15 +138,9 @@ func (c *checker) lookupTypeParam(name string) (*typeinfo.TypeParam, bool) {
 	return nil, false
 }
 
-func (c *checker) symbolMutable(sym *symbols.Symbol) bool {
+func (c *checker) symbolDeclaredMutable(sym *symbols.Symbol) bool {
 	if sym == nil {
 		return false
-	}
-	scope := c.currentLambdaScope()
-	if scope != nil && !scope.move {
-		if _, captured := scope.captures[sym.ID]; captured {
-			return false
-		}
 	}
 	if sym.Kind == symbols.SymbolConst {
 		return false
@@ -160,6 +155,23 @@ func (c *checker) symbolMutable(sym *symbols.Symbol) bool {
 	default:
 		return sym.Flags.Mutable()
 	}
+}
+
+func (c *checker) symbolMutable(sym *symbols.Symbol) bool {
+	if sym == nil {
+		return false
+	}
+	scope := c.currentLambdaScope()
+	if scope != nil && !scope.move {
+		if _, captured := scope.captures[sym.ID]; captured {
+			_, wantsMut := scope.captureMut[sym.ID]
+			if wantsMut {
+				return c.symbolDeclaredMutable(sym)
+			}
+			return false
+		}
+	}
+	return c.symbolDeclaredMutable(sym)
 }
 
 func (c *checker) bindDeclSymbol(node ast.Node, typ typeinfo.Type) {
@@ -190,9 +202,10 @@ func (c *checker) pushLambdaScope(move bool) *lambdaScope {
 		return nil
 	}
 	scope := &lambdaScope{
-		owned:    make(map[symbols.SymbolID]struct{}),
-		captures: make(map[symbols.SymbolID]*symbols.Symbol),
-		move:     move,
+		owned:      make(map[symbols.SymbolID]struct{}),
+		captures:   make(map[symbols.SymbolID]*symbols.Symbol),
+		captureMut: make(map[symbols.SymbolID]struct{}),
+		move:       move,
 	}
 	c.lambdaScopes = append(c.lambdaScopes, scope)
 	return scope

--- a/internal/analysis/semantics/typechecker/core.go
+++ b/internal/analysis/semantics/typechecker/core.go
@@ -5,7 +5,6 @@ import (
 	"compiler/internal/analysis/semantics/symbols"
 	"compiler/internal/analysis/semantics/typeinfo"
 	"compiler/internal/core/context"
-	"compiler/internal/core/diagnostics"
 	"compiler/internal/core/phase"
 	"compiler/internal/frontend/ast"
 )
@@ -23,7 +22,8 @@ type refineScope struct {
 
 type lambdaScope struct {
 	owned    map[symbols.SymbolID]struct{}
-	reported map[symbols.SymbolID]struct{}
+	captures map[symbols.SymbolID]*symbols.Symbol
+	move     bool
 }
 
 func newRefineScope(parent *refineScope) *refineScope {
@@ -139,6 +139,12 @@ func (c *checker) symbolMutable(sym *symbols.Symbol) bool {
 	if sym == nil {
 		return false
 	}
+	scope := c.currentLambdaScope()
+	if scope != nil && !scope.move {
+		if _, captured := scope.captures[sym.ID]; captured {
+			return false
+		}
+	}
 	if sym.Kind == symbols.SymbolConst {
 		return false
 	}
@@ -177,13 +183,14 @@ func (c *checker) declSymbol(node ast.Node) *symbols.Symbol {
 	return res.Symbol
 }
 
-func (c *checker) pushLambdaScope() *lambdaScope {
+func (c *checker) pushLambdaScope(move bool) *lambdaScope {
 	if c == nil {
 		return nil
 	}
 	scope := &lambdaScope{
 		owned:    make(map[symbols.SymbolID]struct{}),
-		reported: make(map[symbols.SymbolID]struct{}),
+		captures: make(map[symbols.SymbolID]*symbols.Symbol),
+		move:     move,
 	}
 	c.lambdaScopes = append(c.lambdaScopes, scope)
 	return scope
@@ -222,16 +229,7 @@ func (c *checker) reportLambdaCapture(ident *ast.Ident, sym *symbols.Symbol) {
 	if _, ok := scope.owned[sym.ID]; ok {
 		return
 	}
-	if _, ok := scope.reported[sym.ID]; ok {
-		return
-	}
-	scope.reported[sym.ID] = struct{}{}
-	loc := ident.Location
-	c.ctx.Diagnostics.Add(
-		diagnostics.NewError("capturing lambdas are not supported yet").
-			WithCode(diagnostics.ErrInvalidOperation).
-			WithPrimaryLabel(&loc, "this lambda captures an outer local value"),
-	)
+	scope.captures[sym.ID] = sym
 }
 
 func (c *checker) isLambdaCaptureCandidate(sym *symbols.Symbol) bool {

--- a/internal/analysis/semantics/typechecker/core.go
+++ b/internal/analysis/semantics/typechecker/core.go
@@ -84,6 +84,7 @@ type checker struct {
 	currentGenericFunc         *symbols.Symbol
 	currentGenericRequirements []*typeinfo.GenericRequirement
 	lambdaScopes               []*lambdaScope
+	allowCapturedLambdaValue   int
 }
 
 func (c *checker) pushTypeParams(mod *context.Module, owner ast.Node, params []ast.TypeParam) []*typeinfo.TypeParam {

--- a/internal/analysis/semantics/typechecker/core.go
+++ b/internal/analysis/semantics/typechecker/core.go
@@ -6,6 +6,7 @@ import (
 	"compiler/internal/analysis/semantics/typeinfo"
 	"compiler/internal/core/context"
 	"compiler/internal/core/phase"
+	"compiler/internal/core/source"
 	"compiler/internal/frontend/ast"
 )
 
@@ -84,6 +85,7 @@ type checker struct {
 	currentGenericFunc         *symbols.Symbol
 	currentGenericRequirements []*typeinfo.GenericRequirement
 	lambdaScopes               []*lambdaScope
+	movedSymbols               map[symbols.SymbolID]source.Location
 }
 
 func (c *checker) pushTypeParams(mod *context.Module, owner ast.Node, params []ast.TypeParam) []*typeinfo.TypeParam {
@@ -271,6 +273,42 @@ func (c *checker) bindNodeSymbolResolution(node ast.Node, sym *symbols.Symbol) {
 	})
 }
 
+func (c *checker) markMovedSymbol(sym *symbols.Symbol, loc source.Location) {
+	if c == nil || sym == nil {
+		return
+	}
+	if !c.symbolMovesOwnership(sym) {
+		return
+	}
+	if c.movedSymbols == nil {
+		c.movedSymbols = make(map[symbols.SymbolID]source.Location)
+	}
+	if _, exists := c.movedSymbols[sym.ID]; exists {
+		return
+	}
+	c.movedSymbols[sym.ID] = loc
+}
+
+func (c *checker) movedSymbolLocation(sym *symbols.Symbol) (source.Location, bool) {
+	if c == nil || sym == nil || len(c.movedSymbols) == 0 {
+		return source.Location{}, false
+	}
+	loc, ok := c.movedSymbols[sym.ID]
+	return loc, ok
+}
+
+func (c *checker) symbolMovesOwnership(sym *symbols.Symbol) bool {
+	if sym == nil {
+		return false
+	}
+	switch sym.Kind {
+	case symbols.SymbolParam, symbols.SymbolVar:
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *checker) ownerTypeDeclForFunc(mod *context.Module, fn *ast.FuncDecl) (*context.Module, *ast.TypeDecl) {
 	if c == nil || fn == nil || fn.OwnerType == nil {
 		return nil, nil
@@ -314,9 +352,10 @@ func CheckModule(ctx *context.CompilerContext, mod *context.Module) {
 		return
 	}
 	c := &checker{
-		ctx:  ctx,
-		mod:  mod,
-		info: typeinfo.NewModuleInfo(),
+		ctx:          ctx,
+		mod:          mod,
+		info:         typeinfo.NewModuleInfo(),
+		movedSymbols: make(map[symbols.SymbolID]source.Location),
 	}
 
 	seenSymbols := make(map[symbols.SymbolID]struct{})

--- a/internal/analysis/semantics/typechecker/stmts.go
+++ b/internal/analysis/semantics/typechecker/stmts.go
@@ -224,6 +224,23 @@ func (c *checker) checkAssignmentTarget(scope *refineScope, left ast.Expr) {
 		if res == nil || res.Kind != binding.ResolutionSymbol || res.Symbol == nil {
 			return
 		}
+		lambdaScope := c.currentLambdaScope()
+		capturedByLambda := false
+		if lambdaScope != nil && !lambdaScope.move {
+			_, capturedByLambda = lambdaScope.captures[res.Symbol.ID]
+		}
+		if capturedByLambda {
+			lambdaScope.captureMut[res.Symbol.ID] = struct{}{}
+			if !c.symbolMutable(res.Symbol) {
+				loc := e.Location
+				c.ctx.Diagnostics.Add(
+					diagnostics.NewError(fmt.Sprintf("cannot assign to immutable symbol %q", res.Symbol.Name)).
+						WithCode(diagnostics.ErrConstantReassignment).
+						WithPrimaryLabel(&loc, "symbol must be mutable"),
+				)
+			}
+			return
+		}
 		if res.Symbol.Kind == symbols.SymbolConst {
 			loc := e.Location
 			c.ctx.Diagnostics.Add(

--- a/internal/analysis/semantics/typechecker/typechecker.go
+++ b/internal/analysis/semantics/typechecker/typechecker.go
@@ -489,6 +489,19 @@ func (c *checker) getTypeOfIdent(scope *refineScope, ident *ast.Ident) typeinfo.
 		return typeinfo.InvalidType{}
 	}
 	if res.Kind == binding.ResolutionSymbol && res.Symbol != nil {
+		if movedAt, moved := c.movedSymbolLocation(res.Symbol); moved {
+			loc := ident.Location
+			diag := diagnostics.NewError(fmt.Sprintf("use of moved value %q", res.Symbol.Name)).
+				WithCode(diagnostics.ErrUseAfterMove).
+				WithPrimaryLabel(&loc, "value used after move capture")
+			if movedAt.Start != nil {
+				diag = diag.WithSecondaryLabel(&movedAt, "value moved into closure here")
+			}
+			c.ctx.Diagnostics.Add(diag)
+			typ := typeinfo.InvalidType{}
+			c.info.BindNode(ident, typ)
+			return typ
+		}
 		c.reportLambdaCapture(ident, res.Symbol)
 		if scope != nil && len(ident.Path) == 1 {
 			if typ, ok := c.lookupRefinedType(scope, ident); ok && typ != nil {
@@ -1299,6 +1312,11 @@ func (c *checker) typeOfLambda(scope *refineScope, expr *ast.LambdaExpr, expecte
 			return orderedCaptures[i].ID < orderedCaptures[j].ID
 		})
 		c.info.BindLambdaCaptures(expr, orderedCaptures)
+		if expr.IsMove {
+			for _, sym := range orderedCaptures {
+				c.markMovedSymbol(sym, expr.Location)
+			}
+		}
 	}
 	c.info.BindNode(expr, fnType)
 	return fnType

--- a/internal/analysis/semantics/typechecker/typechecker.go
+++ b/internal/analysis/semantics/typechecker/typechecker.go
@@ -490,6 +490,18 @@ func (c *checker) getTypeOfIdent(scope *refineScope, ident *ast.Ident) typeinfo.
 	}
 	if res.Kind == binding.ResolutionSymbol && res.Symbol != nil {
 		c.reportLambdaCapture(ident, res.Symbol)
+		if c.allowCapturedLambdaValue == 0 {
+			if lambda, captures, ok := c.capturedLambdaForSymbol(res.Symbol); ok && lambda != nil && len(captures) > 0 {
+				loc := ident.Location
+				c.ctx.Diagnostics.Add(
+					diagnostics.NewError("captured lambda cannot be used as a function value yet").
+						WithCode(diagnostics.ErrInvalidOperation).
+						WithPrimaryLabel(&loc, "this lambda requires hidden captured arguments and is only supported in direct calls").
+						WithNote("call this lambda directly where it is referenced"),
+				)
+				return typeinfo.InvalidType{}
+			}
+		}
 		if scope != nil && len(ident.Path) == 1 {
 			if typ, ok := c.lookupRefinedType(scope, ident); ok && typ != nil {
 				c.info.BindNode(ident, typ)
@@ -925,6 +937,28 @@ func (c *checker) typeOfRange(scope *refineScope, expr *ast.RangeExpr) typeinfo.
 	return typ
 }
 
+func (c *checker) capturedLambdaForSymbol(sym *symbols.Symbol) (*ast.LambdaExpr, []*symbols.Symbol, bool) {
+	if c == nil || c.info == nil || sym == nil {
+		return nil, nil, false
+	}
+	var lambda *ast.LambdaExpr
+	switch node := sym.Node.(type) {
+	case *ast.LetDecl:
+		lambda, _ = node.Value.(*ast.LambdaExpr)
+	case *ast.ConstDecl:
+		lambda, _ = node.Value.(*ast.LambdaExpr)
+	case *ast.LetStmt:
+		lambda, _ = node.Value.(*ast.LambdaExpr)
+	case *ast.ConstStmt:
+		lambda, _ = node.Value.(*ast.LambdaExpr)
+	}
+	if lambda == nil {
+		return nil, nil, false
+	}
+	captures, ok := c.info.LookupLambdaCaptures(lambda)
+	return lambda, captures, ok
+}
+
 func (c *checker) checkRangePatternAgainstMatchValue(scope *refineScope, valueType typeinfo.Type, pattern *ast.RangeExpr) {
 	if pattern == nil {
 		return
@@ -1135,7 +1169,9 @@ func (c *checker) typeOfCall(scope *refineScope, expr *ast.CallExpr, expected ty
 		}
 	}
 
+	c.allowCapturedLambdaValue++
 	calleeType := c.typeOfExpr(scope, expr.Callee, nil)
+	c.allowCapturedLambdaValue--
 	if typeinfo.IsInvalid(calleeType) || typeinfo.IsUnknown(calleeType) {
 		return typeinfo.InvalidType{}
 	}

--- a/internal/analysis/semantics/typechecker/typechecker.go
+++ b/internal/analysis/semantics/typechecker/typechecker.go
@@ -490,18 +490,6 @@ func (c *checker) getTypeOfIdent(scope *refineScope, ident *ast.Ident) typeinfo.
 	}
 	if res.Kind == binding.ResolutionSymbol && res.Symbol != nil {
 		c.reportLambdaCapture(ident, res.Symbol)
-		if c.allowCapturedLambdaValue == 0 {
-			if lambda, captures, ok := c.capturedLambdaForSymbol(res.Symbol); ok && lambda != nil && len(captures) > 0 {
-				loc := ident.Location
-				c.ctx.Diagnostics.Add(
-					diagnostics.NewError("captured lambda cannot be used as a function value yet").
-						WithCode(diagnostics.ErrInvalidOperation).
-						WithPrimaryLabel(&loc, "this lambda requires hidden captured arguments and is only supported in direct calls").
-						WithNote("call this lambda directly where it is referenced"),
-				)
-				return typeinfo.InvalidType{}
-			}
-		}
 		if scope != nil && len(ident.Path) == 1 {
 			if typ, ok := c.lookupRefinedType(scope, ident); ok && typ != nil {
 				c.info.BindNode(ident, typ)
@@ -937,28 +925,6 @@ func (c *checker) typeOfRange(scope *refineScope, expr *ast.RangeExpr) typeinfo.
 	return typ
 }
 
-func (c *checker) capturedLambdaForSymbol(sym *symbols.Symbol) (*ast.LambdaExpr, []*symbols.Symbol, bool) {
-	if c == nil || c.info == nil || sym == nil {
-		return nil, nil, false
-	}
-	var lambda *ast.LambdaExpr
-	switch node := sym.Node.(type) {
-	case *ast.LetDecl:
-		lambda, _ = node.Value.(*ast.LambdaExpr)
-	case *ast.ConstDecl:
-		lambda, _ = node.Value.(*ast.LambdaExpr)
-	case *ast.LetStmt:
-		lambda, _ = node.Value.(*ast.LambdaExpr)
-	case *ast.ConstStmt:
-		lambda, _ = node.Value.(*ast.LambdaExpr)
-	}
-	if lambda == nil {
-		return nil, nil, false
-	}
-	captures, ok := c.info.LookupLambdaCaptures(lambda)
-	return lambda, captures, ok
-}
-
 func (c *checker) checkRangePatternAgainstMatchValue(scope *refineScope, valueType typeinfo.Type, pattern *ast.RangeExpr) {
 	if pattern == nil {
 		return
@@ -1169,9 +1135,7 @@ func (c *checker) typeOfCall(scope *refineScope, expr *ast.CallExpr, expected ty
 		}
 	}
 
-	c.allowCapturedLambdaValue++
 	calleeType := c.typeOfExpr(scope, expr.Callee, nil)
-	c.allowCapturedLambdaValue--
 	if typeinfo.IsInvalid(calleeType) || typeinfo.IsUnknown(calleeType) {
 		return typeinfo.InvalidType{}
 	}

--- a/internal/analysis/semantics/typechecker/typechecker.go
+++ b/internal/analysis/semantics/typechecker/typechecker.go
@@ -1198,7 +1198,7 @@ func (c *checker) typeOfLambda(scope *refineScope, expr *ast.LambdaExpr, expecte
 	}
 
 	lambdaScope := newRefineScope(scope)
-	c.pushLambdaScope()
+	c.pushLambdaScope(expr.IsMove)
 	defer c.popLambdaScope()
 	params := make([]typeinfo.ParamSpec, 0, len(expr.Params))
 	for i, param := range expr.Params {

--- a/internal/analysis/semantics/typechecker/typechecker.go
+++ b/internal/analysis/semantics/typechecker/typechecker.go
@@ -3,6 +3,7 @@ package typechecker
 import (
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	"compiler/internal/analysis/semantics/binding"
@@ -1283,6 +1284,22 @@ func (c *checker) typeOfLambda(scope *refineScope, expr *ast.LambdaExpr, expecte
 	}
 
 	fnType := &typeinfo.FuncType{Params: params, Result: resultType}
+	if lambdaCaptureScope := c.currentLambdaScope(); lambdaCaptureScope != nil {
+		orderedCaptures := make([]*symbols.Symbol, 0, len(lambdaCaptureScope.captures))
+		for _, sym := range lambdaCaptureScope.captures {
+			if sym == nil {
+				continue
+			}
+			orderedCaptures = append(orderedCaptures, sym)
+		}
+		sort.Slice(orderedCaptures, func(i, j int) bool {
+			if orderedCaptures[i].ID == orderedCaptures[j].ID {
+				return orderedCaptures[i].Name < orderedCaptures[j].Name
+			}
+			return orderedCaptures[i].ID < orderedCaptures[j].ID
+		})
+		c.info.BindLambdaCaptures(expr, orderedCaptures)
+	}
 	c.info.BindNode(expr, fnType)
 	return fnType
 }

--- a/internal/analysis/semantics/typechecker/typechecker.go
+++ b/internal/analysis/semantics/typechecker/typechecker.go
@@ -1311,10 +1311,23 @@ func (c *checker) typeOfLambda(scope *refineScope, expr *ast.LambdaExpr, expecte
 			}
 			return orderedCaptures[i].ID < orderedCaptures[j].ID
 		})
-		c.info.BindLambdaCaptures(expr, orderedCaptures)
+		captures := make([]typeinfo.LambdaCapture, 0, len(orderedCaptures))
+		for _, sym := range orderedCaptures {
+			if sym == nil {
+				continue
+			}
+			_, wantsMut := lambdaCaptureScope.captureMut[sym.ID]
+			byRef := !expr.IsMove && sym.Kind != symbols.SymbolConst
+			captures = append(captures, typeinfo.LambdaCapture{
+				Symbol:  sym,
+				ByRef:   byRef,
+				Mutable: byRef && wantsMut,
+			})
+		}
+		c.info.BindLambdaCaptures(expr, captures)
 		if expr.IsMove {
-			for _, sym := range orderedCaptures {
-				c.markMovedSymbol(sym, expr.Location)
+			for _, capture := range captures {
+				c.markMovedSymbol(capture.Symbol, expr.Location)
 			}
 		}
 	}

--- a/internal/analysis/semantics/typechecker/typechecker_test.go
+++ b/internal/analysis/semantics/typechecker/typechecker_test.go
@@ -587,7 +587,7 @@ fn main() -> void {
 	}
 }
 
-func TestTypecheckerRejectsPassingCapturedLambdaAsFunctionValue(t *testing.T) {
+func TestTypecheckerAllowsPassingCapturedLambdaAsFunctionValue(t *testing.T) {
 	root := t.TempDir()
 	mustWriteType(t, filepath.Join(root, "main.fer"), `
 fn apply(f: fn(i32) -> i32, x: i32) -> i32 {
@@ -602,22 +602,12 @@ fn main() -> i32 {
 `)
 
 	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
-	if !result.Diagnostics.HasErrors() {
-		t.Fatal("expected captured-lambda function-value diagnostic")
-	}
-	found := false
-	for _, diag := range result.Diagnostics.Diagnostics() {
-		if diag.Code == diagnostics.ErrInvalidOperation && strings.Contains(diag.Message, "captured lambda cannot be used as a function value yet") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected captured-lambda function-value diagnostic, got %#v", result.Diagnostics.Diagnostics())
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
 	}
 }
 
-func TestTypecheckerRejectsReturningCapturedLambdaAsFunctionValue(t *testing.T) {
+func TestTypecheckerAllowsReturningCapturedLambdaAsFunctionValue(t *testing.T) {
 	root := t.TempDir()
 	mustWriteType(t, filepath.Join(root, "main.fer"), `
 fn makeAdder() -> fn(i32) -> i32 {
@@ -628,18 +618,8 @@ fn makeAdder() -> fn(i32) -> i32 {
 `)
 
 	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
-	if !result.Diagnostics.HasErrors() {
-		t.Fatal("expected captured-lambda return diagnostic")
-	}
-	found := false
-	for _, diag := range result.Diagnostics.Diagnostics() {
-		if diag.Code == diagnostics.ErrInvalidOperation && strings.Contains(diag.Message, "captured lambda cannot be used as a function value yet") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected captured-lambda return diagnostic, got %#v", result.Diagnostics.Diagnostics())
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
 	}
 }
 

--- a/internal/analysis/semantics/typechecker/typechecker_test.go
+++ b/internal/analysis/semantics/typechecker/typechecker_test.go
@@ -587,6 +587,50 @@ fn main() -> void {
 	}
 }
 
+func TestTypecheckerRejectsUseAfterMoveCapture(t *testing.T) {
+	root := t.TempDir()
+	mustWriteType(t, filepath.Join(root, "main.fer"), `
+fn main() -> i32 {
+    let x = 1
+    let f = move () => x
+    let _ = f()
+    return x
+}
+`)
+
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
+	if !result.Diagnostics.HasErrors() {
+		t.Fatal("expected use-after-move diagnostic")
+	}
+	found := false
+	for _, diag := range result.Diagnostics.Diagnostics() {
+		if diag.Code == diagnostics.ErrUseAfterMove && strings.Contains(diag.Message, "use of moved value") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected use-after-move diagnostic, got %#v", result.Diagnostics.Diagnostics())
+	}
+}
+
+func TestTypecheckerAllowsUseAfterReadonlyCapture(t *testing.T) {
+	root := t.TempDir()
+	mustWriteType(t, filepath.Join(root, "main.fer"), `
+fn main() -> i32 {
+    let x = 1
+    let f = () => x
+    let _ = f()
+    return x
+}
+`)
+
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+}
+
 func TestTypecheckerAllowsPassingCapturedLambdaAsFunctionValue(t *testing.T) {
 	root := t.TempDir()
 	mustWriteType(t, filepath.Join(root, "main.fer"), `

--- a/internal/analysis/semantics/typechecker/typechecker_test.go
+++ b/internal/analysis/semantics/typechecker/typechecker_test.go
@@ -537,7 +537,7 @@ fn main() -> void {
 	}
 }
 
-func TestTypecheckerRejectsReadonlyCaptureMutation(t *testing.T) {
+func TestTypecheckerAllowsMutableBorrowCaptureMutation(t *testing.T) {
 	root := t.TempDir()
 	mustWriteType(t, filepath.Join(root, "main.fer"), `
 fn main() -> void {
@@ -550,8 +550,26 @@ fn main() -> void {
 `)
 
 	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+}
+
+func TestTypecheckerRejectsImmutableBorrowCaptureMutation(t *testing.T) {
+	root := t.TempDir()
+	mustWriteType(t, filepath.Join(root, "main.fer"), `
+fn main() -> void {
+    let x = 1
+    let apply = () => {
+        x = 2
+    }
+    apply()
+}
+`)
+
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
 	if !result.Diagnostics.HasErrors() {
-		t.Fatal("expected readonly capture mutation diagnostic")
+		t.Fatal("expected capture mutation diagnostic")
 	}
 	found := false
 	for _, diag := range result.Diagnostics.Diagnostics() {
@@ -561,7 +579,7 @@ fn main() -> void {
 		}
 	}
 	if !found {
-		t.Fatalf("expected readonly capture mutation diagnostic, got %#v", result.Diagnostics.Diagnostics())
+		t.Fatalf("expected capture mutation diagnostic, got %#v", result.Diagnostics.Diagnostics())
 	}
 }
 

--- a/internal/analysis/semantics/typechecker/typechecker_test.go
+++ b/internal/analysis/semantics/typechecker/typechecker_test.go
@@ -1,6 +1,7 @@
 package typechecker_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +47,7 @@ fn Origin() -> vec2::Vec2 {
 }
 `)
 
-	result := compiler.New(root, ".fer", diagnostics.NewDiagnosticBag("")).ParseEntry(filepath.Join(root, "main.fer"))
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
 	if result.Diagnostics.HasErrors() {
 		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
 	}
@@ -73,7 +74,7 @@ fn bad() -> i32 {
 }
 `)
 
-	result := compiler.New(root, ".fer", diagnostics.NewDiagnosticBag("")).ParseEntry(filepath.Join(root, "main.fer"))
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
 	if !result.Diagnostics.HasErrors() {
 		t.Fatal("expected invalid return diagnostic")
 	}
@@ -101,7 +102,7 @@ fn main() -> i32 {
 }
 `)
 
-	result := compiler.New(root, ".fer", diagnostics.NewDiagnosticBag("")).ParseEntry(filepath.Join(root, "main.fer"))
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
 	if !result.Diagnostics.HasErrors() {
 		t.Fatal("expected type mismatch diagnostic")
 	}
@@ -128,7 +129,7 @@ fn main() -> i64 {
 }
 `)
 
-	result := compiler.New(root, ".fer", diagnostics.NewDiagnosticBag("")).ParseEntry(filepath.Join(root, "main.fer"))
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
 	if result.Diagnostics.HasErrors() {
 		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
 	}
@@ -521,7 +522,7 @@ fn main() -> void {
 	}
 }
 
-func TestTypecheckerRejectsCapturingLambda(t *testing.T) {
+func TestTypecheckerAllowsReadonlyCaptureLambda(t *testing.T) {
 	root := t.TempDir()
 	mustWriteType(t, filepath.Join(root, "main.fer"), `
 fn main() -> void {
@@ -531,18 +532,58 @@ fn main() -> void {
 `)
 
 	result := compiler.New(root, ".fer", diagnostics.NewDiagnosticBag("")).ParseEntry(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+}
+
+func TestTypecheckerRejectsReadonlyCaptureMutation(t *testing.T) {
+	root := t.TempDir()
+	mustWriteType(t, filepath.Join(root, "main.fer"), `
+fn main() -> void {
+    let mut x = 1
+    let apply = () => {
+        x = 2
+    }
+    apply()
+}
+`)
+
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
 	if !result.Diagnostics.HasErrors() {
-		t.Fatal("expected capturing lambda diagnostic")
+		t.Fatal("expected readonly capture mutation diagnostic")
 	}
 	found := false
 	for _, diag := range result.Diagnostics.Diagnostics() {
-		if strings.Contains(diag.Message, "capturing lambdas are not supported yet") {
+		if diag.Code == diagnostics.ErrConstantReassignment && strings.Contains(diag.Message, "cannot assign to immutable symbol") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected capturing lambda diagnostic, got %#v", result.Diagnostics.Diagnostics())
+		t.Fatalf("expected readonly capture mutation diagnostic, got %#v", result.Diagnostics.Diagnostics())
+	}
+}
+
+func TestTypecheckerAllowsMoveCaptureMutation(t *testing.T) {
+	root := t.TempDir()
+	mustWriteType(t, filepath.Join(root, "main.fer"), `
+fn main() -> void {
+    let mut x = 1
+    let apply = move () => {
+        x = 2
+    }
+    apply()
+}
+`)
+
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		msgs := make([]string, 0, len(result.Diagnostics.Diagnostics()))
+		for _, diag := range result.Diagnostics.Diagnostics() {
+			msgs = append(msgs, fmt.Sprintf("%s: %s", diag.Code, diag.Message))
+		}
+		t.Fatalf("unexpected diagnostics: %v", msgs)
 	}
 }
 

--- a/internal/analysis/semantics/typechecker/typechecker_test.go
+++ b/internal/analysis/semantics/typechecker/typechecker_test.go
@@ -587,6 +587,62 @@ fn main() -> void {
 	}
 }
 
+func TestTypecheckerRejectsPassingCapturedLambdaAsFunctionValue(t *testing.T) {
+	root := t.TempDir()
+	mustWriteType(t, filepath.Join(root, "main.fer"), `
+fn apply(f: fn(i32) -> i32, x: i32) -> i32 {
+    return f(x)
+}
+
+fn main() -> i32 {
+    let k = 10
+    let addk = (y: i32) => k + y
+    return apply(addk, 2)
+}
+`)
+
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
+	if !result.Diagnostics.HasErrors() {
+		t.Fatal("expected captured-lambda function-value diagnostic")
+	}
+	found := false
+	for _, diag := range result.Diagnostics.Diagnostics() {
+		if diag.Code == diagnostics.ErrInvalidOperation && strings.Contains(diag.Message, "captured lambda cannot be used as a function value yet") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected captured-lambda function-value diagnostic, got %#v", result.Diagnostics.Diagnostics())
+	}
+}
+
+func TestTypecheckerRejectsReturningCapturedLambdaAsFunctionValue(t *testing.T) {
+	root := t.TempDir()
+	mustWriteType(t, filepath.Join(root, "main.fer"), `
+fn makeAdder() -> fn(i32) -> i32 {
+    let k = 10
+    let addk = (y: i32) => k + y
+    return addk
+}
+`)
+
+	result := compiler.ParsePathForIDE(filepath.Join(root, "main.fer"))
+	if !result.Diagnostics.HasErrors() {
+		t.Fatal("expected captured-lambda return diagnostic")
+	}
+	found := false
+	for _, diag := range result.Diagnostics.Diagnostics() {
+		if diag.Code == diagnostics.ErrInvalidOperation && strings.Contains(diag.Message, "captured lambda cannot be used as a function value yet") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected captured-lambda return diagnostic, got %#v", result.Diagnostics.Diagnostics())
+	}
+}
+
 func TestTypecheckerHandlesStaticMethodCallWithGenericOwnerTypeArgs(t *testing.T) {
 	root := t.TempDir()
 	mustWriteType(t, filepath.Join(root, "main.fer"), `

--- a/internal/analysis/semantics/typeinfo/module.go
+++ b/internal/analysis/semantics/typeinfo/module.go
@@ -24,7 +24,7 @@ type ModuleInfo struct {
 	Nodes               map[ast.Node]Type
 	Symbols             map[symbols.SymbolID]Type
 	SymbolIndex         map[symbols.SymbolID]*symbols.Symbol
-	LambdaCaptures      map[*ast.LambdaExpr][]*symbols.Symbol
+	LambdaCaptures      map[*ast.LambdaExpr][]LambdaCapture
 	Bools               map[ast.Node]bool
 	ConstValues         map[ast.Node]ConstValue
 	MethodReceivers     map[ast.Node]Type
@@ -32,12 +32,18 @@ type ModuleInfo struct {
 	GenericRequirements map[symbols.SymbolID][]*GenericRequirement
 }
 
+type LambdaCapture struct {
+	Symbol  *symbols.Symbol
+	ByRef   bool
+	Mutable bool
+}
+
 func NewModuleInfo() *ModuleInfo {
 	return &ModuleInfo{
 		Nodes:               make(map[ast.Node]Type),
 		Symbols:             make(map[symbols.SymbolID]Type),
 		SymbolIndex:         make(map[symbols.SymbolID]*symbols.Symbol),
-		LambdaCaptures:      make(map[*ast.LambdaExpr][]*symbols.Symbol),
+		LambdaCaptures:      make(map[*ast.LambdaExpr][]LambdaCapture),
 		Bools:               make(map[ast.Node]bool),
 		ConstValues:         make(map[ast.Node]ConstValue),
 		MethodReceivers:     make(map[ast.Node]Type),
@@ -121,7 +127,7 @@ func (m *ModuleInfo) LookupCallArgs(call *ast.CallExpr) ([]ast.Expr, bool) {
 	return args, ok
 }
 
-func (m *ModuleInfo) BindLambdaCaptures(expr *ast.LambdaExpr, captures []*symbols.Symbol) {
+func (m *ModuleInfo) BindLambdaCaptures(expr *ast.LambdaExpr, captures []LambdaCapture) {
 	if m == nil || expr == nil {
 		return
 	}
@@ -129,12 +135,12 @@ func (m *ModuleInfo) BindLambdaCaptures(expr *ast.LambdaExpr, captures []*symbol
 		delete(m.LambdaCaptures, expr)
 		return
 	}
-	out := make([]*symbols.Symbol, 0, len(captures))
-	for _, sym := range captures {
-		if sym == nil {
+	out := make([]LambdaCapture, 0, len(captures))
+	for _, capture := range captures {
+		if capture.Symbol == nil {
 			continue
 		}
-		out = append(out, sym)
+		out = append(out, capture)
 	}
 	if len(out) == 0 {
 		delete(m.LambdaCaptures, expr)
@@ -143,7 +149,7 @@ func (m *ModuleInfo) BindLambdaCaptures(expr *ast.LambdaExpr, captures []*symbol
 	m.LambdaCaptures[expr] = out
 }
 
-func (m *ModuleInfo) LookupLambdaCaptures(expr *ast.LambdaExpr) ([]*symbols.Symbol, bool) {
+func (m *ModuleInfo) LookupLambdaCaptures(expr *ast.LambdaExpr) ([]LambdaCapture, bool) {
 	if m == nil || expr == nil {
 		return nil, false
 	}

--- a/internal/analysis/semantics/typeinfo/module.go
+++ b/internal/analysis/semantics/typeinfo/module.go
@@ -24,6 +24,7 @@ type ModuleInfo struct {
 	Nodes               map[ast.Node]Type
 	Symbols             map[symbols.SymbolID]Type
 	SymbolIndex         map[symbols.SymbolID]*symbols.Symbol
+	LambdaCaptures      map[*ast.LambdaExpr][]*symbols.Symbol
 	Bools               map[ast.Node]bool
 	ConstValues         map[ast.Node]ConstValue
 	MethodReceivers     map[ast.Node]Type
@@ -36,6 +37,7 @@ func NewModuleInfo() *ModuleInfo {
 		Nodes:               make(map[ast.Node]Type),
 		Symbols:             make(map[symbols.SymbolID]Type),
 		SymbolIndex:         make(map[symbols.SymbolID]*symbols.Symbol),
+		LambdaCaptures:      make(map[*ast.LambdaExpr][]*symbols.Symbol),
 		Bools:               make(map[ast.Node]bool),
 		ConstValues:         make(map[ast.Node]ConstValue),
 		MethodReceivers:     make(map[ast.Node]Type),
@@ -117,6 +119,36 @@ func (m *ModuleInfo) LookupCallArgs(call *ast.CallExpr) ([]ast.Expr, bool) {
 	}
 	args, ok := m.CallArgs[call]
 	return args, ok
+}
+
+func (m *ModuleInfo) BindLambdaCaptures(expr *ast.LambdaExpr, captures []*symbols.Symbol) {
+	if m == nil || expr == nil {
+		return
+	}
+	if len(captures) == 0 {
+		delete(m.LambdaCaptures, expr)
+		return
+	}
+	out := make([]*symbols.Symbol, 0, len(captures))
+	for _, sym := range captures {
+		if sym == nil {
+			continue
+		}
+		out = append(out, sym)
+	}
+	if len(out) == 0 {
+		delete(m.LambdaCaptures, expr)
+		return
+	}
+	m.LambdaCaptures[expr] = out
+}
+
+func (m *ModuleInfo) LookupLambdaCaptures(expr *ast.LambdaExpr) ([]*symbols.Symbol, bool) {
+	if m == nil || expr == nil {
+		return nil, false
+	}
+	captures, ok := m.LambdaCaptures[expr]
+	return captures, ok
 }
 
 func (m *ModuleInfo) BindGenericRequirements(sym *symbols.Symbol, requirements []*GenericRequirement) {

--- a/internal/analysis/semantics/usage/usage.go
+++ b/internal/analysis/semantics/usage/usage.go
@@ -356,6 +356,29 @@ func (a *usageAnalyzer) collectDeclNodesExpr(expr ast.Expr) {
 			return
 		}
 		a.collectDeclNodesExpr(e.Left)
+	case *ast.LambdaExpr:
+		if e == nil {
+			return
+		}
+		for _, p := range e.Params {
+			a.markDeclNode(p.Name)
+			a.collectDeclNodesExpr(p.Default)
+		}
+		// Writes inside lambdas affect unused-mut and borrow semantics for captured
+		// locals. We avoid a full scope-aware write pass by using capture metadata,
+		// but still traverse the body to catch writes to lambda locals.
+		if a.mod != nil && a.mod.Types != nil {
+			if captures, ok := a.mod.Types.LookupLambdaCaptures(e); ok {
+				for _, capture := range captures {
+					if capture.Symbol == nil || !capture.Mutable {
+						continue
+					}
+					a.written[capture.Symbol.ID]++
+				}
+			}
+		}
+		a.collectDeclNodesExpr(e.BodyExpr)
+		a.collectDeclNodesStmt(e.BodyBlock)
 	case *ast.IsExpr:
 		if e == nil {
 			return

--- a/internal/analysis/semantics/usage/usage_test.go
+++ b/internal/analysis/semantics/usage/usage_test.go
@@ -390,6 +390,27 @@ func TestUsageDoesNotWarnWhenMutableBindingIsModifiedThroughMutRef(t *testing.T)
 	}
 }
 
+func TestUsageDoesNotWarnWhenMutableBindingIsModifiedThroughLambdaCapture(t *testing.T) {
+	root := t.TempDir()
+	mustWriteUsage(t, filepath.Join(root, "main.fer"), `fn main() -> void {
+    let mut x = 1
+    let apply = () => { x = 2 }
+    apply()
+    _ = x
+}
+`)
+
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	for _, diag := range result.Diagnostics.Diagnostics() {
+		if diag.Code == diagnostics.WarnUnmodifiedMutable && diag.Message == `"x" is never modified` {
+			t.Fatalf("did not expect never-modified mutable warning, got %#v", result.Diagnostics.Diagnostics())
+		}
+	}
+}
+
 func TestUsageDoesNotWarnOnMutableSliceElementMutation(t *testing.T) {
 	root := t.TempDir()
 	mustWriteUsage(t, filepath.Join(root, "main.fer"), `

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -41,7 +41,6 @@ type moduleState struct {
 	interfaceVTables  map[becommon.InterfaceVTableKey]string
 	interfaceWrappers map[becommon.InterfaceWrapperKey]struct{}
 	runtimeTypes      map[string]string
-	closureDefs       map[string]*mir.Closure
 	closureThunks     map[string]string
 	functionClosures  map[string]string
 	functionThunks    map[string]string
@@ -1022,7 +1021,6 @@ func newModuleState(unit *backend.Unit, allLayouts map[string]*layout.Module) *m
 			interfaceVTables:  shared.VTables,
 			interfaceWrappers: shared.Wrappers,
 			runtimeTypes:      shared.RuntimeTypes,
-			closureDefs:       make(map[string]*mir.Closure),
 			closureThunks:     make(map[string]string),
 			functionClosures:  make(map[string]string),
 			functionThunks:    make(map[string]string),
@@ -1047,16 +1045,10 @@ func newModuleState(unit *backend.Unit, allLayouts map[string]*layout.Module) *m
 		interfaceVTables:  shared.VTables,
 		interfaceWrappers: shared.Wrappers,
 		runtimeTypes:      shared.RuntimeTypes,
-		closureDefs:       make(map[string]*mir.Closure, len(unit.Module.Closures)),
 		closureThunks:     make(map[string]string),
 		functionClosures:  make(map[string]string),
 		functionThunks:    make(map[string]string),
 		tempValues:        make(map[int]mir.Value),
-	}
-	for _, closure := range unit.Module.Closures {
-		if closure != nil {
-			state.closureDefs[closure.Name] = closure
-		}
 	}
 	return state
 }
@@ -3668,29 +3660,51 @@ func lowerCallArgs(state *moduleState, call *mir.CallValue) ([]string, error) {
 	return args, nil
 }
 
-func llvmClosureEnvType(state *moduleState, captures []mir.Value) string {
+type closureCaptureField struct {
+	Value      mir.Value
+	IRType     string
+	ByvalType  string
+	ByvalAlign int64
+}
+
+func closureCaptureFields(state *moduleState, captures []mir.Value) ([]closureCaptureField, string, error) {
 	if state == nil || len(captures) == 0 {
-		return llvmFunctionClosureType()
+		return nil, "{}", nil
 	}
-	fields := make([]string, 0, len(captures))
+	fields := make([]closureCaptureField, 0, len(captures))
+	typeParts := make([]string, 0, len(captures))
 	for _, capture := range captures {
 		if capture == nil || capture.Type() == nil {
 			continue
 		}
-		irType := "ptr"
+		field := closureCaptureField{Value: capture}
 		if isAggregateType(state, capture.Type()) {
-			if tn, err := llvmABITypeName(state, capture.Type()); err == nil {
-				irType = tn
+			typeName, err := llvmABITypeName(state, capture.Type())
+			if err != nil {
+				return nil, "", err
 			}
-		} else if tn, err := llvmBaseType(capture.Type()); err == nil {
-			irType = tn
+			_, align, err := backend.AggregateSizeAlign(aggregateLayoutContext(state), capture.Type())
+			if err != nil {
+				return nil, "", err
+			}
+			field.IRType = "ptr"
+			field.ByvalType = typeName
+			field.ByvalAlign = align
+			typeParts = append(typeParts, "ptr")
+		} else {
+			irType, err := llvmBaseType(capture.Type())
+			if err != nil {
+				return nil, "", err
+			}
+			field.IRType = irType
+			typeParts = append(typeParts, irType)
 		}
-		fields = append(fields, irType)
+		fields = append(fields, field)
 	}
-	if len(fields) == 0 {
-		return "{}"
+	if len(typeParts) == 0 {
+		return nil, "{}", nil
 	}
-	return "{ " + strings.Join(fields, ", ") + " }"
+	return fields, "{ " + strings.Join(typeParts, ", ") + " }", nil
 }
 
 func ensureClosureThunk(state *moduleState, closureName string, funcName string, captures []mir.Value, fnType *typeinfo.FuncType) string {
@@ -3705,7 +3719,10 @@ func ensureClosureThunk(state *moduleState, closureName string, funcName string,
 		return ""
 	}
 	thunk := llvmClosureThunkName(closureName)
-	envType := llvmClosureEnvType(state, captures)
+	captureFields, envType, err := closureCaptureFields(state, captures)
+	if err != nil {
+		return ""
+	}
 	retType := "void"
 	if fnType.Result != nil && !isVoidType(fnType.Result) {
 		if isAggregateType(state, fnType.Result) {
@@ -3718,23 +3735,20 @@ func ensureClosureThunk(state *moduleState, closureName string, funcName string,
 	}
 	params := make([]string, 0, 1+len(fnType.Params))
 	params = append(params, "ptr %env")
-	loadLines := make([]string, 0, len(captures)*2)
+	loadLines := make([]string, 0, len(captureFields)*2)
 	callParts := make([]string, 0, len(targetFn.Params))
-	for i, capture := range captures {
-		if capture == nil || capture.Type() == nil {
-			continue
-		}
-		irType, err := llvmBaseType(capture.Type())
-		if err != nil {
-			return ""
-		}
+	for i, field := range captureFields {
 		slot := fmt.Sprintf("%%cap_ptr%d", i)
 		load := fmt.Sprintf("%%cap%d", i)
 		loadLines = append(loadLines,
 			fmt.Sprintf("%s = getelementptr inbounds %s, ptr %%env, i32 0, i32 %d", slot, envType, i),
-			fmt.Sprintf("%s = load %s, ptr %s", load, irType, slot),
+			fmt.Sprintf("%s = load %s, ptr %s", load, field.IRType, slot),
 		)
-		callParts = append(callParts, fmt.Sprintf("%s %s", irType, load))
+		if field.ByvalType != "" {
+			callParts = append(callParts, fmt.Sprintf("ptr byval(%s) align %d %s", field.ByvalType, field.ByvalAlign, load))
+		} else {
+			callParts = append(callParts, fmt.Sprintf("%s %s", field.IRType, load))
+		}
 	}
 	userArgNames := make([]string, 0, len(fnType.Params))
 	for i, param := range fnType.Params {
@@ -5094,31 +5108,35 @@ func lowerValue(state *moduleState, value mir.Value) (string, error) {
 		}
 		envPtr := "null"
 		if len(v.Captures) > 0 {
-			envType := llvmClosureEnvType(state, v.Captures)
-			envSlot := freshTemp(state, "closure_env")
-			state.pendingLines = append(state.pendingLines, fmt.Sprintf("%s = alloca %s, align %d", envSlot, envType, abi.PointerBytes()))
-			for i, capture := range v.Captures {
-				irType, err := llvmBaseType(capture.Type())
-				if err != nil {
-					return "", err
-				}
-				valueExpr, err := lowerValue(state, capture)
+			captureFields, envType, err := closureCaptureFields(state, v.Captures)
+			if err != nil {
+				return "", err
+			}
+			envSlot := freshTemp(state, "closure_env_heap")
+			envBytes := abi.PointerBytes() * int64(len(captureFields))
+			if envBytes <= 0 {
+				envBytes = abi.PointerBytes()
+			}
+			state.pendingLines = append(state.pendingLines, fmt.Sprintf("%s = call ptr @malloc(%s %d)", envSlot, llvmABIIntType(), envBytes))
+			for i, field := range captureFields {
+				valueExpr, err := lowerValue(state, field.Value)
 				if err != nil {
 					return "", err
 				}
 				fieldPtr := freshTemp(state, "closure_cap")
 				state.pendingLines = append(state.pendingLines,
 					fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d", fieldPtr, envType, envSlot, i),
-					fmt.Sprintf("store %s %s, ptr %s", irType, valueExpr, fieldPtr),
+					fmt.Sprintf("store %s %s, ptr %s", field.IRType, valueExpr, fieldPtr),
 				)
 			}
 			envPtr = envSlot
 		}
-		closureSlot := freshTemp(state, "closure")
+		closureSlot := freshTemp(state, "closure_heap")
 		codePtr := freshTemp(state, "closure_code")
 		envField := freshTemp(state, "closure_env_ptr")
+		closureBytes := abi.PointerBytes() * 2
 		state.pendingLines = append(state.pendingLines,
-			fmt.Sprintf("%s = alloca %s, align %d", closureSlot, llvmFunctionClosureType(), abi.PointerBytes()),
+			fmt.Sprintf("%s = call ptr @malloc(%s %d)", closureSlot, llvmABIIntType(), closureBytes),
 			fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 0", codePtr, llvmFunctionClosureType(), closureSlot),
 			fmt.Sprintf("store ptr @%s, ptr %s", thunk, codePtr),
 			fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 1", envField, llvmFunctionClosureType(), closureSlot),

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -2087,6 +2087,9 @@ func lowerSSAAssign(state *moduleState, name string, typ typeinfo.Type, value mi
 		}
 		return fmt.Sprintf("%s = %s", llvmLocalName(name), copyExpr), nil
 	}
+	if llvmExprIsAtom(expr) {
+		return fmt.Sprintf("%s = %s", llvmLocalName(name), llvmCopyExprUnchecked(irType, expr)), nil
+	}
 	return fmt.Sprintf("%s = %s", llvmLocalName(name), expr), nil
 }
 
@@ -2588,7 +2591,7 @@ func lowerStorePlace(state *moduleState, instr *mir.StoreInstr) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	if !llvmValueNeedsCopy(instr.Value) {
+	if !llvmValueNeedsCopy(instr.Value) && !llvmExprIsAtom(val) {
 		tmp := freshTemp(state, "store")
 		lines = append(lines, fmt.Sprintf("%s = %s", tmp, val))
 		val = tmp
@@ -6505,6 +6508,22 @@ func llvmCopyExprUnchecked(irType, valExpr string) string {
 	default:
 		return fmt.Sprintf("or %s 0, %s", irType, valExpr)
 	}
+}
+
+func llvmExprIsAtom(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return false
+	}
+	if strings.HasPrefix(expr, "%") || strings.HasPrefix(expr, "@") {
+		return true
+	}
+	switch expr {
+	case "null", "undef":
+		return true
+	}
+	first := expr[0]
+	return first == '-' || (first >= '0' && first <= '9')
 }
 
 func llvmValueNeedsCopy(v mir.Value) bool {

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -3672,6 +3672,8 @@ type closureCaptureField struct {
 	IRType     string
 	ByvalType  string
 	ByvalAlign int64
+	CopyBytes  int64
+	CopyAlign  int64
 }
 
 func closureCaptureFields(state *moduleState, captures []mir.Value) ([]closureCaptureField, string, error) {
@@ -3690,13 +3692,15 @@ func closureCaptureFields(state *moduleState, captures []mir.Value) ([]closureCa
 			if err != nil {
 				return nil, "", err
 			}
-			_, align, err := backend.AggregateSizeAlign(aggregateLayoutContext(state), capture.Type())
+			size, align, err := backend.AggregateSizeAlign(aggregateLayoutContext(state), capture.Type())
 			if err != nil {
 				return nil, "", err
 			}
 			field.IRType = "ptr"
 			field.ByvalType = typeName
 			field.ByvalAlign = align
+			field.CopyBytes = size
+			field.CopyAlign = align
 			typeParts = append(typeParts, "ptr")
 		} else {
 			irType, err := llvmBaseType(capture.Type())
@@ -5120,6 +5124,14 @@ func lowerValue(state *moduleState, value mir.Value) (string, error) {
 				valueExpr, err := lowerValue(state, field.Value)
 				if err != nil {
 					return "", err
+				}
+				if field.ByvalType != "" {
+					captureHeap := freshTemp(state, "closure_cap_heap")
+					state.pendingLines = append(state.pendingLines,
+						fmt.Sprintf("%s = call ptr @malloc(%s %d)", captureHeap, llvmABIIntType(), field.CopyBytes),
+						llvmMemcpy(captureHeap, valueExpr, field.CopyBytes, field.CopyAlign),
+					)
+					valueExpr = captureHeap
 				}
 				fieldPtr := freshTemp(state, "closure_cap")
 				state.pendingLines = append(state.pendingLines,

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -41,7 +41,10 @@ type moduleState struct {
 	interfaceVTables  map[becommon.InterfaceVTableKey]string
 	interfaceWrappers map[becommon.InterfaceWrapperKey]struct{}
 	runtimeTypes      map[string]string
+	closureDefs       map[string]*mir.Closure
+	closureThunks     map[string]string
 	functionClosures  map[string]string
+	functionThunks    map[string]string
 	tempValues        map[int]mir.Value
 	debug             *debugState // nil if debug info is disabled
 	fnScopeID         int         // DISubprogram metadata ID for the current function
@@ -1019,7 +1022,10 @@ func newModuleState(unit *backend.Unit, allLayouts map[string]*layout.Module) *m
 			interfaceVTables:  shared.VTables,
 			interfaceWrappers: shared.Wrappers,
 			runtimeTypes:      shared.RuntimeTypes,
+			closureDefs:       make(map[string]*mir.Closure),
+			closureThunks:     make(map[string]string),
 			functionClosures:  make(map[string]string),
+			functionThunks:    make(map[string]string),
 			tempValues:        make(map[int]mir.Value),
 		}
 	}
@@ -1041,8 +1047,16 @@ func newModuleState(unit *backend.Unit, allLayouts map[string]*layout.Module) *m
 		interfaceVTables:  shared.VTables,
 		interfaceWrappers: shared.Wrappers,
 		runtimeTypes:      shared.RuntimeTypes,
+		closureDefs:       make(map[string]*mir.Closure, len(unit.Module.Closures)),
+		closureThunks:     make(map[string]string),
 		functionClosures:  make(map[string]string),
+		functionThunks:    make(map[string]string),
 		tempValues:        make(map[int]mir.Value),
+	}
+	for _, closure := range unit.Module.Closures {
+		if closure != nil {
+			state.closureDefs[closure.Name] = closure
+		}
 	}
 	return state
 }
@@ -3513,17 +3527,97 @@ func llvmFunctionClosureType() string {
 	return "{ ptr, ptr }"
 }
 
-func ensureFunctionClosureGlobal(state *moduleState, target string) string {
-	if state == nil || target == "" {
+func llvmClosureThunkName(name string) string {
+	return becommon.SanitizeLinkName(name + "__thunk")
+}
+
+func findMIRFunction(state *moduleState, name string) *mir.Function {
+	if state == nil || name == "" {
+		return nil
+	}
+	if state.mod != nil {
+		for _, fn := range state.mod.Functions {
+			if fn != nil && fn.Name == name {
+				return fn
+			}
+		}
+	}
+	for _, mod := range state.modules {
+		if mod == nil {
+			continue
+		}
+		for _, fn := range mod.Functions {
+			if fn != nil && fn.Name == name {
+				return fn
+			}
+		}
+	}
+	return nil
+}
+
+func emitClosureThunk(state *moduleState, thunkName string, target string, retType string, params []string, callArgs []string) {
+	if state == nil || thunkName == "" || target == "" {
+		return
+	}
+	fmt.Fprintf(state.deferredB, "define %s @%s(%s) {\nentry:\n", retType, thunkName, strings.Join(params, ", "))
+	if retType == "void" {
+		fmt.Fprintf(state.deferredB, "  call void @%s(%s)\n", target, strings.Join(callArgs, ", "))
+		fmt.Fprintf(state.deferredB, "  ret void\n")
+	} else {
+		fmt.Fprintf(state.deferredB, "  %%ret = call %s @%s(%s)\n", retType, target, strings.Join(callArgs, ", "))
+		fmt.Fprintf(state.deferredB, "  ret %s %%ret\n", retType)
+	}
+	fmt.Fprintf(state.deferredB, "}\n")
+}
+
+func ensureNamedFunctionThunk(state *moduleState, target string, fnType *typeinfo.FuncType) string {
+	if state == nil || target == "" || fnType == nil {
 		return ""
 	}
-	if sym, ok := state.functionClosures[target]; ok {
+	if sym, ok := state.functionThunks[target]; ok {
 		return sym
 	}
+	retType := "void"
+	if fnType.Result != nil && !isVoidType(fnType.Result) {
+		if isAggregateType(state, fnType.Result) {
+			if tn, err := llvmABITypeName(state, fnType.Result); err == nil {
+				retType = tn
+			}
+		} else if tn, err := llvmBaseType(fnType.Result); err == nil {
+			retType = tn
+		}
+	}
+	params := make([]string, 0, 1+len(fnType.Params))
+	callArgs := make([]string, 0, len(fnType.Params))
+	params = append(params, "ptr %env")
+	for i, param := range fnType.Params {
+		irType, err := llvmBaseType(param.Type)
+		if err != nil {
+			irType = "ptr"
+		}
+		name := fmt.Sprintf("%%arg%d", i)
+		params = append(params, fmt.Sprintf("%s %s", irType, name))
+		callArgs = append(callArgs, fmt.Sprintf("%s %s", irType, name))
+	}
+	thunk := llvmClosureThunkName(target)
+	emitClosureThunk(state, thunk, target, retType, params, callArgs)
+	state.functionThunks[target] = thunk
+	return thunk
+}
+
+func ensureFunctionClosureGlobal(state *moduleState, target string, fnType *typeinfo.FuncType) string {
+	if state == nil || target == "" || fnType == nil {
+		return ""
+	}
+	key := target + "|" + fnType.String()
+	if sym, ok := state.functionClosures[key]; ok {
+		return sym
+	}
+	thunk := ensureNamedFunctionThunk(state, target, fnType)
 	sym := nextPrivateGlobalSymbol(state, "fnval")
 	fmt.Fprintf(state.deferredB, "@%s = private unnamed_addr constant %s { ptr @%s, ptr null }\n",
-		sym, llvmFunctionClosureType(), target)
-	state.functionClosures[target] = sym
+		sym, llvmFunctionClosureType(), thunk)
+	state.functionClosures[key] = sym
 	return sym
 }
 
@@ -3574,6 +3668,109 @@ func lowerCallArgs(state *moduleState, call *mir.CallValue) ([]string, error) {
 	return args, nil
 }
 
+func llvmClosureEnvType(state *moduleState, captures []mir.Value) string {
+	if state == nil || len(captures) == 0 {
+		return llvmFunctionClosureType()
+	}
+	fields := make([]string, 0, len(captures))
+	for _, capture := range captures {
+		if capture == nil || capture.Type() == nil {
+			continue
+		}
+		irType := "ptr"
+		if isAggregateType(state, capture.Type()) {
+			if tn, err := llvmABITypeName(state, capture.Type()); err == nil {
+				irType = tn
+			}
+		} else if tn, err := llvmBaseType(capture.Type()); err == nil {
+			irType = tn
+		}
+		fields = append(fields, irType)
+	}
+	if len(fields) == 0 {
+		return "{}"
+	}
+	return "{ " + strings.Join(fields, ", ") + " }"
+}
+
+func ensureClosureThunk(state *moduleState, closureName string, funcName string, captures []mir.Value, fnType *typeinfo.FuncType) string {
+	if state == nil || closureName == "" || funcName == "" || fnType == nil {
+		return ""
+	}
+	if sym, ok := state.closureThunks[closureName]; ok {
+		return sym
+	}
+	targetFn := findMIRFunction(state, funcName)
+	if targetFn == nil {
+		return ""
+	}
+	thunk := llvmClosureThunkName(closureName)
+	envType := llvmClosureEnvType(state, captures)
+	retType := "void"
+	if fnType.Result != nil && !isVoidType(fnType.Result) {
+		if isAggregateType(state, fnType.Result) {
+			if tn, err := llvmABITypeName(state, fnType.Result); err == nil {
+				retType = tn
+			}
+		} else if tn, err := llvmBaseType(fnType.Result); err == nil {
+			retType = tn
+		}
+	}
+	params := make([]string, 0, 1+len(fnType.Params))
+	params = append(params, "ptr %env")
+	loadLines := make([]string, 0, len(captures)*2)
+	callParts := make([]string, 0, len(targetFn.Params))
+	for i, capture := range captures {
+		if capture == nil || capture.Type() == nil {
+			continue
+		}
+		irType, err := llvmBaseType(capture.Type())
+		if err != nil {
+			return ""
+		}
+		slot := fmt.Sprintf("%%cap_ptr%d", i)
+		load := fmt.Sprintf("%%cap%d", i)
+		loadLines = append(loadLines,
+			fmt.Sprintf("%s = getelementptr inbounds %s, ptr %%env, i32 0, i32 %d", slot, envType, i),
+			fmt.Sprintf("%s = load %s, ptr %s", load, irType, slot),
+		)
+		callParts = append(callParts, fmt.Sprintf("%s %s", irType, load))
+	}
+	userArgNames := make([]string, 0, len(fnType.Params))
+	for i, param := range fnType.Params {
+		irType, err := llvmBaseType(param.Type)
+		if err != nil {
+			irType = "ptr"
+		}
+		name := fmt.Sprintf("%%arg%d", i)
+		params = append(params, fmt.Sprintf("%s %s", irType, name))
+		userArgNames = append(userArgNames, fmt.Sprintf("%s %s", irType, name))
+	}
+	body := &strings.Builder{}
+	fmt.Fprintf(body, "define %s @%s(%s) {\nentry:\n", retType, thunk, strings.Join(params, ", "))
+	for _, line := range loadLines {
+		fmt.Fprintf(body, "  %s\n", line)
+	}
+	callParts = append(callParts, userArgNames...)
+	target := targetFn.Name
+	if targetFn.LinkName != "" {
+		target = becommon.SanitizeLinkName(targetFn.LinkName)
+	} else {
+		target = llvmSymbol(state, []string{targetFn.Name})
+	}
+	if retType == "void" {
+		fmt.Fprintf(body, "  call void @%s(%s)\n", target, strings.Join(callParts, ", "))
+		fmt.Fprintf(body, "  ret void\n")
+	} else {
+		fmt.Fprintf(body, "  %%ret = call %s @%s(%s)\n", retType, target, strings.Join(callParts, ", "))
+		fmt.Fprintf(body, "  ret %s %%ret\n", retType)
+	}
+	fmt.Fprintf(body, "}\n")
+	state.deferredB.WriteString(body.String())
+	state.closureThunks[closureName] = thunk
+	return thunk
+}
+
 func lowerDirectCallee(state *moduleState, value mir.Value) (string, bool) {
 	named, ok := value.(*mir.NameValue)
 	if !ok || named == nil {
@@ -3594,9 +3791,13 @@ func lowerDirectCallee(state *moduleState, value mir.Value) (string, bool) {
 func lowerFunctionValueCall(state *moduleState, targetName string, targetType typeinfo.Type, closurePtr string, args []string) (string, error) {
 	codeAddr := freshTemp(state, "fn_code_addr")
 	code := freshTemp(state, "fn_code")
+	envAddr := freshTemp(state, "fn_env_addr")
+	env := freshTemp(state, "fn_env")
 	lines := []string{
 		fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 0", codeAddr, llvmFunctionClosureType(), closurePtr),
 		fmt.Sprintf("%s = load ptr, ptr %s", code, codeAddr),
+		fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 1", envAddr, llvmFunctionClosureType(), closurePtr),
+		fmt.Sprintf("%s = load ptr, ptr %s", env, envAddr),
 	}
 
 	var retStr string
@@ -3615,7 +3816,8 @@ func lowerFunctionValueCall(state *moduleState, targetName string, targetType ty
 	} else {
 		retStr = "void"
 	}
-	callText := fmt.Sprintf("call %s %s(%s)", retStr, code, strings.Join(args, ", "))
+	callArgs := append([]string{fmt.Sprintf("ptr %s", env)}, args...)
+	callText := fmt.Sprintf("call %s %s(%s)", retStr, code, strings.Join(callArgs, ", "))
 	if targetName == "" || retStr == "void" {
 		lines = append(lines, callText)
 		return strings.Join(lines, "\n"), nil
@@ -4832,7 +5034,8 @@ func lowerValue(state *moduleState, value mir.Value) (string, error) {
 			if v.LinkName != "" {
 				target = becommon.SanitizeLinkName(v.LinkName)
 			}
-			return "@" + ensureFunctionClosureGlobal(state, target), nil
+			fnType, _ := v.Type().(*typeinfo.FuncType)
+			return "@" + ensureFunctionClosureGlobal(state, target, fnType), nil
 		}
 		if !isAggregateType(state, v.Type()) {
 			irType, err := llvmBaseType(v.Type())
@@ -4880,6 +5083,48 @@ func lowerValue(state *moduleState, value mir.Value) (string, error) {
 		return lowerTypeTest(state, v)
 	case *mir.CallValue:
 		return "", fmt.Errorf("call value must be lowered in assignment/eval context")
+	case *mir.ClosureValue:
+		fnType, _ := v.Type().(*typeinfo.FuncType)
+		if fnType == nil {
+			return "", fmt.Errorf("unknown closure value %q", v.Name)
+		}
+		thunk := ensureClosureThunk(state, v.Name, v.FuncName, v.Captures, fnType)
+		if thunk == "" {
+			return "", fmt.Errorf("missing closure thunk for %q", v.Name)
+		}
+		envPtr := "null"
+		if len(v.Captures) > 0 {
+			envType := llvmClosureEnvType(state, v.Captures)
+			envSlot := freshTemp(state, "closure_env")
+			state.pendingLines = append(state.pendingLines, fmt.Sprintf("%s = alloca %s, align %d", envSlot, envType, abi.PointerBytes()))
+			for i, capture := range v.Captures {
+				irType, err := llvmBaseType(capture.Type())
+				if err != nil {
+					return "", err
+				}
+				valueExpr, err := lowerValue(state, capture)
+				if err != nil {
+					return "", err
+				}
+				fieldPtr := freshTemp(state, "closure_cap")
+				state.pendingLines = append(state.pendingLines,
+					fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d", fieldPtr, envType, envSlot, i),
+					fmt.Sprintf("store %s %s, ptr %s", irType, valueExpr, fieldPtr),
+				)
+			}
+			envPtr = envSlot
+		}
+		closureSlot := freshTemp(state, "closure")
+		codePtr := freshTemp(state, "closure_code")
+		envField := freshTemp(state, "closure_env_ptr")
+		state.pendingLines = append(state.pendingLines,
+			fmt.Sprintf("%s = alloca %s, align %d", closureSlot, llvmFunctionClosureType(), abi.PointerBytes()),
+			fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 0", codePtr, llvmFunctionClosureType(), closureSlot),
+			fmt.Sprintf("store ptr @%s, ptr %s", thunk, codePtr),
+			fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 1", envField, llvmFunctionClosureType(), closureSlot),
+			fmt.Sprintf("store ptr %s, ptr %s", envPtr, envField),
+		)
+		return closureSlot, nil
 	case *mir.FieldLoadValue:
 		return "", fmt.Errorf("field load must be lowered in assignment context")
 	case *mir.CompositeValue:

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -5118,11 +5118,13 @@ func lowerValue(state *moduleState, value mir.Value) (string, error) {
 				return "", err
 			}
 			envSlot := freshTemp(state, "closure_env_heap")
-			envBytes := abi.PointerBytes() * int64(len(captureFields))
-			if envBytes <= 0 {
-				envBytes = abi.PointerBytes()
-			}
-			state.pendingLines = append(state.pendingLines, fmt.Sprintf("%s = call ptr @malloc(%s %d)", envSlot, llvmABIIntType(), envBytes))
+			envSizePtr := freshTemp(state, "closure_env_size_ptr")
+			envBytes := freshTemp(state, "closure_env_size")
+			state.pendingLines = append(state.pendingLines,
+				fmt.Sprintf("%s = getelementptr inbounds %s, ptr null, i32 1", envSizePtr, envType),
+				fmt.Sprintf("%s = ptrtoint ptr %s to %s", envBytes, envSizePtr, llvmABIIntType()),
+				fmt.Sprintf("%s = call ptr @malloc(%s %s)", envSlot, llvmABIIntType(), envBytes),
+			)
 			for i, field := range captureFields {
 				valueExpr, err := lowerValue(state, field.Value)
 				if err != nil {

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -3562,6 +3562,22 @@ func emitClosureThunk(state *moduleState, thunkName string, target string, retTy
 	fmt.Fprintf(state.deferredB, "}\n")
 }
 
+func callableReturnIRType(state *moduleState, fnType *typeinfo.FuncType) string {
+	if fnType == nil || fnType.Result == nil || isVoidType(fnType.Result) {
+		return "void"
+	}
+	if isAggregateType(state, fnType.Result) {
+		if tn, err := llvmABITypeName(state, fnType.Result); err == nil {
+			return tn
+		}
+		return "void"
+	}
+	if tn, err := llvmBaseType(fnType.Result); err == nil {
+		return tn
+	}
+	return "void"
+}
+
 func ensureNamedFunctionThunk(state *moduleState, target string, fnType *typeinfo.FuncType) string {
 	if state == nil || target == "" || fnType == nil {
 		return ""
@@ -3569,16 +3585,7 @@ func ensureNamedFunctionThunk(state *moduleState, target string, fnType *typeinf
 	if sym, ok := state.functionThunks[target]; ok {
 		return sym
 	}
-	retType := "void"
-	if fnType.Result != nil && !isVoidType(fnType.Result) {
-		if isAggregateType(state, fnType.Result) {
-			if tn, err := llvmABITypeName(state, fnType.Result); err == nil {
-				retType = tn
-			}
-		} else if tn, err := llvmBaseType(fnType.Result); err == nil {
-			retType = tn
-		}
-	}
+	retType := callableReturnIRType(state, fnType)
 	params := make([]string, 0, 1+len(fnType.Params))
 	callArgs := make([]string, 0, len(fnType.Params))
 	params = append(params, "ptr %env")
@@ -3723,16 +3730,7 @@ func ensureClosureThunk(state *moduleState, closureName string, funcName string,
 	if err != nil {
 		return ""
 	}
-	retType := "void"
-	if fnType.Result != nil && !isVoidType(fnType.Result) {
-		if isAggregateType(state, fnType.Result) {
-			if tn, err := llvmABITypeName(state, fnType.Result); err == nil {
-				retType = tn
-			}
-		} else if tn, err := llvmBaseType(fnType.Result); err == nil {
-			retType = tn
-		}
-	}
+	retType := callableReturnIRType(state, fnType)
 	params := make([]string, 0, 1+len(fnType.Params))
 	params = append(params, "ptr %env")
 	loadLines := make([]string, 0, len(captureFields)*2)

--- a/internal/backend/llvm/llvm.go
+++ b/internal/backend/llvm/llvm.go
@@ -41,6 +41,7 @@ type moduleState struct {
 	interfaceVTables  map[becommon.InterfaceVTableKey]string
 	interfaceWrappers map[becommon.InterfaceWrapperKey]struct{}
 	runtimeTypes      map[string]string
+	functionClosures  map[string]string
 	tempValues        map[int]mir.Value
 	debug             *debugState // nil if debug info is disabled
 	fnScopeID         int         // DISubprogram metadata ID for the current function
@@ -1018,6 +1019,7 @@ func newModuleState(unit *backend.Unit, allLayouts map[string]*layout.Module) *m
 			interfaceVTables:  shared.VTables,
 			interfaceWrappers: shared.Wrappers,
 			runtimeTypes:      shared.RuntimeTypes,
+			functionClosures:  make(map[string]string),
 			tempValues:        make(map[int]mir.Value),
 		}
 	}
@@ -1039,6 +1041,7 @@ func newModuleState(unit *backend.Unit, allLayouts map[string]*layout.Module) *m
 		interfaceVTables:  shared.VTables,
 		interfaceWrappers: shared.Wrappers,
 		runtimeTypes:      shared.RuntimeTypes,
+		functionClosures:  make(map[string]string),
 		tempValues:        make(map[int]mir.Value),
 	}
 	return state
@@ -2802,56 +2805,22 @@ func lowerCall(state *moduleState, targetName string, targetType typeinfo.Type, 
 	if kind, mapType, ok := becommon.BuiltinMapCall(call); ok {
 		return lowerBuiltinMapCall(state, targetName, targetType, call, kind, mapType)
 	}
-	callee, err := lowerCallee(state, call.Callee)
+	args, err := lowerCallArgs(state, call)
 	if err != nil {
 		return "", err
 	}
-
-	// Inline builtins: string_ptr and string_len have been removed.
-	// String literals are now *i8 — no special callee interception needed.
-
-	args := make([]string, 0, len(call.Args))
-	externLinked := false
-	if callee, ok := call.Callee.(*mir.NameValue); ok && callee != nil && callee.LinkName != "" {
-		externLinked = true
-	}
-	for _, arg := range call.Args {
-		if isAggregateType(state, arg.Type()) {
-			if externLinked {
-				prefix, ptr, terr := lowerInterfaceConcretePointer(state, arg, arg.Type())
-				if terr != nil {
-					return "", terr
-				}
-				if len(prefix) != 0 {
-					state.pendingLines = append(state.pendingLines, prefix...)
-				}
-				args = append(args, fmt.Sprintf("ptr %s", ptr))
-				continue
+	if _, ok := call.Callee.Type().(*typeinfo.FuncType); ok {
+		if _, direct := lowerDirectCallee(state, call.Callee); !direct {
+			closurePtr, err := lowerValue(state, call.Callee)
+			if err != nil {
+				return "", err
 			}
-			typeName, terr := llvmABITypeName(state, arg.Type())
-			if terr != nil {
-				return "", terr
-			}
-			_, align, terr := backend.AggregateSizeAlign(aggregateLayoutContext(state), arg.Type())
-			if terr != nil {
-				return "", terr
-			}
-			aval, terr := lowerValue(state, arg)
-			if terr != nil {
-				return "", terr
-			}
-			args = append(args, fmt.Sprintf("ptr byval(%s) align %d %s", typeName, align, aval))
-		} else {
-			atype, terr := llvmBaseType(arg.Type())
-			if terr != nil {
-				return "", terr
-			}
-			aval, terr := lowerValue(state, arg)
-			if terr != nil {
-				return "", terr
-			}
-			args = append(args, fmt.Sprintf("%s %s", atype, aval))
+			return lowerFunctionValueCall(state, targetName, targetType, closurePtr, args)
 		}
+	}
+	callee, err := lowerCallee(state, call.Callee)
+	if err != nil {
+		return "", err
 	}
 	argsStr := strings.Join(args, ", ")
 
@@ -3540,6 +3509,121 @@ func emitStringConstant(state *moduleState, s string) string {
 	return sym
 }
 
+func llvmFunctionClosureType() string {
+	return "{ ptr, ptr }"
+}
+
+func ensureFunctionClosureGlobal(state *moduleState, target string) string {
+	if state == nil || target == "" {
+		return ""
+	}
+	if sym, ok := state.functionClosures[target]; ok {
+		return sym
+	}
+	sym := nextPrivateGlobalSymbol(state, "fnval")
+	fmt.Fprintf(state.deferredB, "@%s = private unnamed_addr constant %s { ptr @%s, ptr null }\n",
+		sym, llvmFunctionClosureType(), target)
+	state.functionClosures[target] = sym
+	return sym
+}
+
+func lowerCallArgs(state *moduleState, call *mir.CallValue) ([]string, error) {
+	args := make([]string, 0, len(call.Args))
+	externLinked := false
+	if callee, ok := call.Callee.(*mir.NameValue); ok && callee != nil && callee.LinkName != "" {
+		externLinked = true
+	}
+	for _, arg := range call.Args {
+		if isAggregateType(state, arg.Type()) {
+			if externLinked {
+				prefix, ptr, err := lowerInterfaceConcretePointer(state, arg, arg.Type())
+				if err != nil {
+					return nil, err
+				}
+				if len(prefix) != 0 {
+					state.pendingLines = append(state.pendingLines, prefix...)
+				}
+				args = append(args, fmt.Sprintf("ptr %s", ptr))
+				continue
+			}
+			typeName, err := llvmABITypeName(state, arg.Type())
+			if err != nil {
+				return nil, err
+			}
+			_, align, err := backend.AggregateSizeAlign(aggregateLayoutContext(state), arg.Type())
+			if err != nil {
+				return nil, err
+			}
+			aval, err := lowerValue(state, arg)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, fmt.Sprintf("ptr byval(%s) align %d %s", typeName, align, aval))
+			continue
+		}
+		atype, err := llvmBaseType(arg.Type())
+		if err != nil {
+			return nil, err
+		}
+		aval, err := lowerValue(state, arg)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, fmt.Sprintf("%s %s", atype, aval))
+	}
+	return args, nil
+}
+
+func lowerDirectCallee(state *moduleState, value mir.Value) (string, bool) {
+	named, ok := value.(*mir.NameValue)
+	if !ok || named == nil {
+		return "", false
+	}
+	if _, ok := named.Type().(*typeinfo.FuncType); !ok {
+		return "", false
+	}
+	if len(named.Path) == 1 && becommon.FindLocalByName(state.fn, named.Path[0]) != nil {
+		return "", false
+	}
+	if named.LinkName != "" {
+		return becommon.SanitizeLinkName(named.LinkName), true
+	}
+	return llvmSymbol(state, named.Path), true
+}
+
+func lowerFunctionValueCall(state *moduleState, targetName string, targetType typeinfo.Type, closurePtr string, args []string) (string, error) {
+	codeAddr := freshTemp(state, "fn_code_addr")
+	code := freshTemp(state, "fn_code")
+	lines := []string{
+		fmt.Sprintf("%s = getelementptr inbounds %s, ptr %s, i32 0, i32 0", codeAddr, llvmFunctionClosureType(), closurePtr),
+		fmt.Sprintf("%s = load ptr, ptr %s", code, codeAddr),
+	}
+
+	var retStr string
+	if targetType != nil && isAggregateType(state, targetType) {
+		tn, err := llvmABITypeName(state, targetType)
+		if err != nil {
+			return "", err
+		}
+		retStr = tn
+	} else if targetType != nil && !isVoidType(targetType) {
+		rt, err := llvmBaseType(targetType)
+		if err != nil {
+			return "", err
+		}
+		retStr = rt
+	} else {
+		retStr = "void"
+	}
+	callText := fmt.Sprintf("call %s %s(%s)", retStr, code, strings.Join(args, ", "))
+	if targetName == "" || retStr == "void" {
+		lines = append(lines, callText)
+		return strings.Join(lines, "\n"), nil
+	}
+	lines = append(lines, fmt.Sprintf("%s = %s", llvmLocalName(targetName), callText))
+	return strings.Join(lines, "\n"), nil
+}
+
 func lowerAggregateCallValue(state *moduleState, agg *aggregateLocal, call *mir.CallValue) (string, error) {
 	if local, ok := call.Callee.(*mir.LocalValue); ok && len(call.Args) > 0 && isInterfaceAggregate(call.Args[0].Type()) {
 		if field, ok := state.tempValues[local.LocalID].(*mir.FieldValue); ok {
@@ -3552,52 +3636,32 @@ func lowerAggregateCallValue(state *moduleState, agg *aggregateLocal, call *mir.
 	if kind, mapType, ok := becommon.BuiltinMapCall(call); ok {
 		return lowerBuiltinMapCall(state, agg.Name, agg.Type, call, kind, mapType)
 	}
-	callee, err := lowerCallee(state, call.Callee)
+	args, err := lowerCallArgs(state, call)
 	if err != nil {
 		return "", err
 	}
-	args := make([]string, 0, len(call.Args))
-	externLinked := false
-	if callee, ok := call.Callee.(*mir.NameValue); ok && callee != nil && callee.LinkName != "" {
-		externLinked = true
-	}
-	for _, arg := range call.Args {
-		if isAggregateType(state, arg.Type()) {
-			if externLinked {
-				prefix, ptr, terr := lowerInterfaceConcretePointer(state, arg, arg.Type())
-				if terr != nil {
-					return "", terr
-				}
-				if len(prefix) != 0 {
-					state.pendingLines = append(state.pendingLines, prefix...)
-				}
-				args = append(args, fmt.Sprintf("ptr %s", ptr))
-				continue
+	if _, ok := call.Callee.Type().(*typeinfo.FuncType); ok {
+		if _, direct := lowerDirectCallee(state, call.Callee); !direct {
+			closurePtr, err := lowerValue(state, call.Callee)
+			if err != nil {
+				return "", err
 			}
-			typeName, terr := llvmABITypeName(state, arg.Type())
-			if terr != nil {
-				return "", terr
+			callTemp := "aggret"
+			lowered, err := lowerFunctionValueCall(state, callTemp, agg.Type, closurePtr, args)
+			if err != nil {
+				return "", err
 			}
-			_, align, terr := backend.AggregateSizeAlign(aggregateLayoutContext(state), arg.Type())
-			if terr != nil {
-				return "", terr
+			typeName, err := llvmABITypeName(state, agg.Type)
+			if err != nil {
+				return "", err
 			}
-			aval, terr := lowerValue(state, arg)
-			if terr != nil {
-				return "", terr
-			}
-			args = append(args, fmt.Sprintf("ptr byval(%s) align %d %s", typeName, align, aval))
-		} else {
-			atype, terr := llvmBaseType(arg.Type())
-			if terr != nil {
-				return "", terr
-			}
-			aval, terr := lowerValue(state, arg)
-			if terr != nil {
-				return "", terr
-			}
-			args = append(args, fmt.Sprintf("%s %s", atype, aval))
+			lines := []string{lowered, fmt.Sprintf("store %s %s, ptr %s", typeName, llvmLocalName(callTemp), llvmLocalName(agg.PtrName))}
+			return strings.Join(lines, "\n"), nil
 		}
+	}
+	callee, err := lowerCallee(state, call.Callee)
+	if err != nil {
+		return "", err
 	}
 	typeName, err := llvmABITypeName(state, agg.Type)
 	if err != nil {
@@ -4764,10 +4828,11 @@ func lowerValue(state *moduleState, value mir.Value) (string, error) {
 			}
 		}
 		if _, ok := v.Type().(*typeinfo.FuncType); ok {
+			target := llvmSymbol(state, v.Path)
 			if v.LinkName != "" {
-				return "@" + becommon.SanitizeLinkName(v.LinkName), nil
+				target = becommon.SanitizeLinkName(v.LinkName)
 			}
-			return "@" + llvmSymbol(state, v.Path), nil
+			return "@" + ensureFunctionClosureGlobal(state, target), nil
 		}
 		if !isAggregateType(state, v.Type()) {
 			irType, err := llvmBaseType(v.Type())
@@ -5474,6 +5539,9 @@ func lowerCallee(state *moduleState, value mir.Value) (string, error) {
 		}
 	case *mir.NameValue:
 		if _, ok := v.Type().(*typeinfo.FuncType); ok {
+			if direct, ok := lowerDirectCallee(state, v); ok {
+				return direct, nil
+			}
 			return lowerValue(state, v)
 		}
 		if v.LinkName != "" {

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -2447,8 +2447,11 @@ fn apply(f: fn(i32) -> i32, x: i32) -> i32 {
 	if !strings.Contains(text, "define i32 @main__apply(ptr %f, i32 %x)") {
 		t.Fatalf("expected function-typed parameter in llvm output:\n%s", text)
 	}
-	if !strings.Contains(text, "call i32 %_ld2(i32 %_ld3)") {
-		t.Fatalf("expected indirect function-value call in llvm output:\n%s", text)
+	if !strings.Contains(text, "getelementptr inbounds { ptr, ptr }, ptr %_ld3, i32 0, i32 0") {
+		t.Fatalf("expected closure code load for function-value call in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "call i32 %_fn_code") {
+		t.Fatalf("expected indirect closure call in llvm output:\n%s", text)
 	}
 }
 
@@ -2496,6 +2499,9 @@ fn main() -> i32 {
 	}
 	if !strings.Contains(text, "%local__main__Server = type { [16 x i8] }") {
 		t.Fatalf("expected Server route table type in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "private unnamed_addr constant { ptr, ptr } { ptr @main__inc, ptr null }") {
+		t.Fatalf("expected static function closure object in llvm output:\n%s", text)
 	}
 }
 

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -2415,8 +2415,14 @@ fn main() -> i32 {
 	if !strings.Contains(text, "define i32 @main____lambda") {
 		t.Fatalf("expected synthetic lambda function in llvm output:\n%s", text)
 	}
-	if !strings.Contains(text, "call i32 @main____lambda1(i32 5, i32 2)") {
-		t.Fatalf("expected captured value passed into lambda call in llvm output:\n%s", text)
+	if !strings.Contains(text, "define i32 @__lambda1__closure__thunk(ptr %env, i32 %arg0)") {
+		t.Fatalf("expected captured closure thunk in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "call i32 @main____lambda1(i32 %cap0, i32 %arg0)") {
+		t.Fatalf("expected thunk to forward captured value into lambda call in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "call i32 %_fn_code") || !strings.Contains(text, "ptr %_fn_env") {
+		t.Fatalf("expected indirect closure call with env pointer in llvm output:\n%s", text)
 	}
 }
 
@@ -2500,7 +2506,7 @@ fn main() -> i32 {
 	if !strings.Contains(text, "%local__main__Server = type { [16 x i8] }") {
 		t.Fatalf("expected Server route table type in llvm output:\n%s", text)
 	}
-	if !strings.Contains(text, "private unnamed_addr constant { ptr, ptr } { ptr @main__inc, ptr null }") {
+	if !strings.Contains(text, "private unnamed_addr constant { ptr, ptr } { ptr @main__inc__thunk, ptr null }") {
 		t.Fatalf("expected static function closure object in llvm output:\n%s", text)
 	}
 }

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -2580,6 +2580,46 @@ fn main() -> i32 {
 	}
 }
 
+func TestLowerCapturedAggregateLambdaCopiesCaptureToHeapEnv(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+type Pair struct {
+    x: i32
+    y: i32
+}
+
+fn makeFn() -> fn(i32) -> i32 {
+    let p: Pair = .{ .x = 10, .y = 20 }
+    let addx = (n: i32) => p.x + n
+    return addx
+}
+
+fn main() -> i32 {
+    let f = makeFn()
+    return f(1)
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetLLVM)
+	if err != nil {
+		t.Fatalf("unexpected llvm error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower llvm: %v", err)
+	}
+	text := artifact.Text
+	if !strings.Contains(text, "closure_cap_heap") {
+		t.Fatalf("expected aggregate capture heap copy slot in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "call void @llvm.memcpy.p0.p0.") {
+		t.Fatalf("expected aggregate capture memcpy into closure env in llvm output:\n%s", text)
+	}
+}
+
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -2620,6 +2620,42 @@ fn main() -> i32 {
 	}
 }
 
+func TestLowerClosureEnvAllocationUsesComputedStructSize(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+fn make() -> fn() -> i64 {
+    let a: i64 = 10
+    let b: i32 = 20
+    let f = move () => a + (b as i64)
+    return f
+}
+
+fn main() -> i64 {
+    let f = make()
+    return f()
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetLLVM)
+	if err != nil {
+		t.Fatalf("unexpected llvm error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower llvm: %v", err)
+	}
+	text := artifact.Text
+	if !strings.Contains(text, "getelementptr inbounds { i64, i32 }, ptr null, i32 1") {
+		t.Fatalf("expected closure env size to be computed from struct layout in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "ptrtoint ptr %_closure_env_size_ptr") {
+		t.Fatalf("expected computed closure env byte size in llvm output:\n%s", text)
+	}
+}
+
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -2511,6 +2511,75 @@ fn main() -> i32 {
 	}
 }
 
+func TestLowerPassingCapturedLambdaAsFunctionValueToLLVM(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+fn apply(f: fn(i32) -> i32, x: i32) -> i32 {
+    return f(x)
+}
+
+fn main() -> i32 {
+    let k = 10
+    let addk = (y: i32) => k + y
+    return apply(addk, 2)
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetLLVM)
+	if err != nil {
+		t.Fatalf("unexpected llvm error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower llvm: %v", err)
+	}
+	text := artifact.Text
+	if !strings.Contains(text, "__closure__thunk") {
+		t.Fatalf("expected captured closure thunk in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "call i32 @main__apply(ptr ") {
+		t.Fatalf("expected closure value to be passed into apply in llvm output:\n%s", text)
+	}
+}
+
+func TestLowerReturningCapturedLambdaAsFunctionValueToLLVM(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+fn makeAdder() -> fn(i32) -> i32 {
+    let k = 10
+    let addk = (y: i32) => k + y
+    return addk
+}
+
+fn main() -> i32 {
+    let add2 = makeAdder()
+    return add2(3)
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetLLVM)
+	if err != nil {
+		t.Fatalf("unexpected llvm error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower llvm: %v", err)
+	}
+	text := artifact.Text
+	if !strings.Contains(text, "define ptr @main__makeAdder()") {
+		t.Fatalf("expected makeAdder to return function value pointer in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "call i32 %_fn_code") || !strings.Contains(text, "ptr %_fn_env") {
+		t.Fatalf("expected indirect closure call with env from returned value in llvm output:\n%s", text)
+	}
+}
+
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -2135,8 +2135,8 @@ fn main() -> i32 {
 		"store i32 0, ptr %value",
 		"%_br3 = icmp ne i8",
 		"br i1 %_br3, label %bb1, label %bb2",
-		"store i32 %_asgn9, ptr %__match1_alloca",
-		"ret i32 %_ld12",
+		"store i32 %_ld7, ptr %__match1_alloca",
+		"ret i32 %_ld10",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected %q in llvm output:\n%s", want, text)
@@ -2418,7 +2418,7 @@ fn main() -> i32 {
 	if !strings.Contains(text, "define i32 @__lambda1__closure__thunk(ptr %env, i32 %arg0)") {
 		t.Fatalf("expected captured closure thunk in llvm output:\n%s", text)
 	}
-	if !strings.Contains(text, "call i32 @main____lambda1(i32 %cap0, i32 %arg0)") {
+	if !strings.Contains(text, "call i32 @main____lambda1(ptr %cap0, i32 %arg0)") {
 		t.Fatalf("expected thunk to forward captured value into lambda call in llvm output:\n%s", text)
 	}
 	if !strings.Contains(text, "call i32 %_fn_code") || !strings.Contains(text, "ptr %_fn_env") {
@@ -2590,7 +2590,7 @@ type Pair struct {
 
 fn makeFn() -> fn(i32) -> i32 {
     let p: Pair = .{ .x = 10, .y = 20 }
-    let addx = (n: i32) => p.x + n
+    let addx = move (n: i32) => p.x + n
     return addx
 }
 

--- a/internal/backend/llvm/lower_test.go
+++ b/internal/backend/llvm/lower_test.go
@@ -2390,6 +2390,36 @@ fn main() -> i32 {
 	}
 }
 
+func TestLowerCapturedLambdaCallToLLVM(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "main.fer"), `
+fn main() -> i32 {
+    let x = 5
+    let addx = (y: i32) => x + y
+    return addx(2)
+}
+`)
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	lowerer, err := registry.New(backend.TargetLLVM)
+	if err != nil {
+		t.Fatalf("unexpected llvm error: %v", err)
+	}
+	artifact, err := lowerer.LowerModule(testUnit(result))
+	if err != nil {
+		t.Fatalf("lower llvm: %v", err)
+	}
+	text := artifact.Text
+	if !strings.Contains(text, "define i32 @main____lambda") {
+		t.Fatalf("expected synthetic lambda function in llvm output:\n%s", text)
+	}
+	if !strings.Contains(text, "call i32 @main____lambda1(i32 5, i32 2)") {
+		t.Fatalf("expected captured value passed into lambda call in llvm output:\n%s", text)
+	}
+}
+
 func TestLowerFunctionValueParameterCallToLLVM(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "main.fer"), `

--- a/internal/frontend/ast/clone.go
+++ b/internal/frontend/ast/clone.go
@@ -394,7 +394,7 @@ func CloneExprWithNodeMapAndSubstitute(expr Expr, substitute func(Node) Expr) (E
 			}
 			return out
 		case *LambdaExpr:
-			out := &LambdaExpr{BodyExpr: cloneExpr(e.BodyExpr), BodyBlock: cloneBlock(e.BodyBlock), Location: e.Location}
+			out := &LambdaExpr{BodyExpr: cloneExpr(e.BodyExpr), BodyBlock: cloneBlock(e.BodyBlock), IsMove: e.IsMove, Location: e.Location}
 			mapping[e] = out
 			if len(e.Params) > 0 {
 				out.Params = make([]Param, 0, len(e.Params))

--- a/internal/frontend/ast/debug.go
+++ b/internal/frontend/ast/debug.go
@@ -227,7 +227,7 @@ func debugExpr(expr Expr) any {
 		for _, param := range e.Params {
 			params = append(params, debugParam(param))
 		}
-		return map[string]any{"kind": "LambdaExpr", "params": params, "body_expr": debugExpr(e.BodyExpr), "body_block": debugStmt(e.BodyBlock), "loc": debugLoc(e.Location)}
+		return map[string]any{"kind": "LambdaExpr", "move": e.IsMove, "params": params, "body_expr": debugExpr(e.BodyExpr), "body_block": debugStmt(e.BodyBlock), "loc": debugLoc(e.Location)}
 	case *SelectorExpr:
 		return map[string]any{"kind": "SelectorExpr", "left": debugExpr(e.Left), "name": debugExpr(e.Name), "loc": debugLoc(e.Location)}
 	case *CastExpr:

--- a/internal/frontend/ast/expr.go
+++ b/internal/frontend/ast/expr.go
@@ -139,6 +139,7 @@ type LambdaExpr struct {
 	Params    []Param
 	BodyExpr  Expr
 	BodyBlock *BlockStmt
+	IsMove    bool
 	Location  source.Location
 }
 

--- a/internal/frontend/ast/format.go
+++ b/internal/frontend/ast/format.go
@@ -197,6 +197,9 @@ func ExprString(expr Expr) string {
 			parts = append(parts, text)
 		}
 		head := "(" + strings.Join(parts, ", ") + ") =>"
+		if e.IsMove {
+			head = "move " + head
+		}
 		if e.BodyExpr != nil {
 			return head + " " + ExprString(e.BodyExpr)
 		}

--- a/internal/frontend/parser/expr.go
+++ b/internal/frontend/parser/expr.go
@@ -110,9 +110,18 @@ func (p *Parser) parsePrefix() ast.Expr {
 		return &ast.NoneLit{Location: p.locFrom(start)}
 	case tokens.LPAREN:
 		if p.hasLambdaArrowAhead() {
-			return p.parseLambdaExpr()
+			return p.parseLambdaExpr(false)
 		}
 		return p.parseParenExpr()
+	case tokens.MOVE:
+		if p.pos+1 < len(p.toks) && p.toks[p.pos+1].Kind == tokens.LPAREN && p.hasLambdaArrowAheadFrom(p.pos+1) {
+			p.advance()
+			return p.parseLambdaExpr(true)
+		}
+		loc := p.locFrom(start)
+		p.errorAt(loc, "`move` is only valid before lambda expressions")
+		p.advance()
+		return &ast.BadExpr{Location: loc}
 	case tokens.LBRACE:
 		return p.parseBraceCompositeLit()
 	case tokens.DOT:
@@ -202,7 +211,7 @@ func (p *Parser) parseParenExpr() ast.Expr {
 	return &ast.CompositeLit{Items: items, Tuple: true, Location: p.locFrom(start)}
 }
 
-func (p *Parser) parseLambdaExpr() ast.Expr {
+func (p *Parser) parseLambdaExpr(isMove bool) ast.Expr {
 	start := p.expect(tokens.LPAREN, "expected '('").Start
 	params := make([]ast.Param, 0)
 	for !p.at(tokens.RPAREN) && !p.at(tokens.EOF) {
@@ -229,10 +238,10 @@ func (p *Parser) parseLambdaExpr() ast.Expr {
 	p.expect(tokens.FATARROW, "expected '=>' after lambda parameters")
 	if p.at(tokens.LBRACE) {
 		body := p.parseBlock()
-		return &ast.LambdaExpr{Params: params, BodyBlock: body, Location: p.locFrom(start)}
+		return &ast.LambdaExpr{Params: params, BodyBlock: body, IsMove: isMove, Location: p.locFrom(start)}
 	}
 	bodyExpr := p.parseExprUntil(precLowest)
-	return &ast.LambdaExpr{Params: params, BodyExpr: bodyExpr, Location: p.locFrom(start)}
+	return &ast.LambdaExpr{Params: params, BodyExpr: bodyExpr, IsMove: isMove, Location: p.locFrom(start)}
 }
 
 func (p *Parser) parseCompositeLit() ast.Expr {

--- a/internal/frontend/parser/parser.go
+++ b/internal/frontend/parser/parser.go
@@ -706,11 +706,15 @@ func (p *Parser) startsNamedParam() bool {
 }
 
 func (p *Parser) hasLambdaArrowAhead() bool {
-	if !p.at(tokens.LPAREN) {
+	return p.hasLambdaArrowAheadFrom(p.pos)
+}
+
+func (p *Parser) hasLambdaArrowAheadFrom(start int) bool {
+	if start < 0 || start >= len(p.toks) || p.toks[start].Kind != tokens.LPAREN {
 		return false
 	}
 	depth := 0
-	for i := p.pos; i < len(p.toks); i++ {
+	for i := start; i < len(p.toks); i++ {
 		switch p.toks[i].Kind {
 		case tokens.LPAREN:
 			depth++

--- a/internal/frontend/parser/parser_test.go
+++ b/internal/frontend/parser/parser_test.go
@@ -302,6 +302,7 @@ fn main() -> void {
     let log = (msg: str) => {
         println(msg)
     }
+    let moved = move (x: i32) => x
 }
 `
 
@@ -314,8 +315,8 @@ fn main() -> void {
 		t.Fatalf("expected func decl, got %T", mod.Decls[0])
 	}
 	body := fn.Body
-	if body == nil || len(body.Stmts) != 2 {
-		t.Fatalf("expected two statements, got %#v", body)
+	if body == nil || len(body.Stmts) != 3 {
+		t.Fatalf("expected three statements, got %#v", body)
 	}
 	letAdd, ok := body.Stmts[0].(*ast.LetStmt)
 	if !ok {
@@ -341,6 +342,17 @@ fn main() -> void {
 	}
 	if blockLambda.BodyBlock == nil || blockLambda.BodyExpr != nil {
 		t.Fatalf("expected block-bodied lambda, got %#v", blockLambda)
+	}
+	letMoved, ok := body.Stmts[2].(*ast.LetStmt)
+	if !ok {
+		t.Fatalf("expected let stmt, got %T", body.Stmts[2])
+	}
+	moveLambda, ok := letMoved.Value.(*ast.LambdaExpr)
+	if !ok {
+		t.Fatalf("expected lambda expr, got %T", letMoved.Value)
+	}
+	if !moveLambda.IsMove {
+		t.Fatalf("expected move lambda, got %#v", moveLambda)
 	}
 }
 

--- a/internal/ir/hir/expr.go
+++ b/internal/ir/hir/expr.go
@@ -76,6 +76,15 @@ type CallExpr struct {
 
 func (*CallExpr) exprNode() {}
 
+type ClosureLit struct {
+	baseExpr
+	Name     string
+	FuncName string
+	Captures []Expr
+}
+
+func (*ClosureLit) exprNode() {}
+
 type SelectorExpr struct {
 	baseExpr
 	Left Expr

--- a/internal/ir/hir/format.go
+++ b/internal/ir/hir/format.go
@@ -289,6 +289,12 @@ func formatExpr(expr Expr) string {
 			parts = append(parts, formatExpr(arg))
 		}
 		return fmt.Sprintf("%s(%s)", wrapExpr(e.Callee), strings.Join(parts, ", "))
+	case *ClosureLit:
+		parts := make([]string, 0, len(e.Captures))
+		for _, capture := range e.Captures {
+			parts = append(parts, formatExpr(capture))
+		}
+		return fmt.Sprintf("closure %s[%s]", e.FuncName, strings.Join(parts, ", "))
 	case *SelectorExpr:
 		return fmt.Sprintf("%s.%s", wrapExpr(e.Left), e.Name)
 	case *CastExpr:
@@ -436,7 +442,7 @@ func formatInterfaceParams(receiver string, params []*Param) string {
 
 func wrapExpr(expr Expr) string {
 	switch expr.(type) {
-	case *Ident, *NumberLit, *StringLit, *NoneLit, *SelectorExpr, *CallExpr, *CompositeLit:
+	case *Ident, *NumberLit, *StringLit, *NoneLit, *SelectorExpr, *CallExpr, *CompositeLit, *ClosureLit:
 		return formatExpr(expr)
 	default:
 		return "(" + formatExpr(expr) + ")"

--- a/internal/ir/hir/generate.go
+++ b/internal/ir/hir/generate.go
@@ -29,6 +29,7 @@ type generator struct {
 	localIDs      map[symbols.SymbolID]int
 	usedNames     map[string]struct{}
 	synthFuncs    []*Func
+	synthClosures []*Closure
 }
 
 func Generate(key, importPath, filePath string, astMod *ast.Module, types *typeinfo.ModuleInfo, bindings *binding.ModuleInfo, lookupMethod MethodLookup) *Module {
@@ -52,6 +53,7 @@ func Generate(key, importPath, filePath string, astMod *ast.Module, types *typei
 		Source:     astMod,
 		Types:      make([]*TypeDecl, 0),
 		Globals:    make([]*Global, 0),
+		Closures:   make([]*Closure, 0),
 		Functions:  make([]*Func, 0),
 	}
 	for _, decl := range astMod.Decls {
@@ -66,6 +68,7 @@ func Generate(key, importPath, filePath string, astMod *ast.Module, types *typei
 			out.Functions = append(out.Functions, g.generateFunc(d))
 		}
 	}
+	out.Closures = append(out.Closures, g.synthClosures...)
 	out.Functions = append(out.Functions, g.synthFuncs...)
 	return out
 }
@@ -451,6 +454,38 @@ func (g *generator) generateLambdaFunc(expr *ast.LambdaExpr, fnType *typeinfo.Fu
 	}
 	g.lambdaNames[expr] = fn.Name
 	captures := g.lambdaCaptureSymbols(expr)
+	if len(captures) > 0 {
+		closure := &Closure{
+			Name:       fn.Name + "__closure",
+			FuncName:   fn.Name,
+			Captures:   make([]*Param, 0, len(captures)),
+			Location:   expr.Location,
+			LambdaExpr: expr,
+		}
+		for _, captured := range captures {
+			if captured == nil {
+				continue
+			}
+			captureType := typeinfo.Type(typeinfo.UnknownType{})
+			if g.types != nil {
+				if typ := g.types.Symbols[captured.ID]; typ != nil {
+					captureType = typ
+				}
+			}
+			localID := -1
+			if id, ok := g.ensureLocalID(captured); ok {
+				localID = id
+			}
+			closure.Captures = append(closure.Captures, &Param{
+				Name:      g.mangleLocal(captured),
+				LocalID:   localID,
+				Type:      captureType,
+				IsMutable: expr.IsMove && g.symbolMutableForLambdaCapture(captured),
+				Location:  captured.Location,
+			})
+		}
+		g.synthClosures = append(g.synthClosures, closure)
+	}
 	fn.Params = make([]*Param, 0, len(captures)+len(expr.Params))
 	for _, captured := range captures {
 		captureType := typeinfo.Type(typeinfo.UnknownType{})

--- a/internal/ir/hir/generate.go
+++ b/internal/ir/hir/generate.go
@@ -20,16 +20,18 @@ type generator struct {
 	bindings     *binding.ModuleInfo
 	lookupMethod MethodLookup
 
-	currentFn     *ast.FuncDecl
-	currentResult typeinfo.Type
-	inFunction    bool
-	nextLambda    int
-	lambdaNames   map[ast.Expr]string
-	localNames    map[symbols.SymbolID]string
-	localIDs      map[symbols.SymbolID]int
-	usedNames     map[string]struct{}
-	synthFuncs    []*Func
-	synthClosures []*Closure
+	currentFn          *ast.FuncDecl
+	currentResult      typeinfo.Type
+	inFunction         bool
+	activeLambda       map[symbols.SymbolID]typeinfo.LambdaCapture
+	activeLambdaLocals map[int]typeinfo.LambdaCapture
+	nextLambda         int
+	lambdaNames        map[ast.Expr]string
+	localNames         map[symbols.SymbolID]string
+	localIDs           map[symbols.SymbolID]int
+	usedNames          map[string]struct{}
+	synthFuncs         []*Func
+	synthClosures      []*Closure
 }
 
 func Generate(key, importPath, filePath string, astMod *ast.Module, types *typeinfo.ModuleInfo, bindings *binding.ModuleInfo, lookupMethod MethodLookup) *Module {
@@ -439,11 +441,26 @@ func (g *generator) generateLambdaFunc(expr *ast.LambdaExpr, fnType *typeinfo.Fu
 	if expr == nil || fnType == nil {
 		return nil
 	}
-	prevFn, prevResult, prevActive, prevUsed, prevNames, prevIDs := g.currentFn, g.currentResult, g.inFunction, g.usedNames, g.localNames, g.localIDs
+	prevFn, prevResult, prevActive, prevUsed, prevNames, prevIDs, prevLambda, prevLambdaLocals := g.currentFn, g.currentResult, g.inFunction, g.usedNames, g.localNames, g.localIDs, g.activeLambda, g.activeLambdaLocals
 	g.beginSyntheticFunction(fnType.Result)
 	defer func() {
-		g.currentFn, g.currentResult, g.inFunction, g.usedNames, g.localNames, g.localIDs = prevFn, prevResult, prevActive, prevUsed, prevNames, prevIDs
+		g.currentFn, g.currentResult, g.inFunction, g.usedNames, g.localNames, g.localIDs, g.activeLambda, g.activeLambdaLocals = prevFn, prevResult, prevActive, prevUsed, prevNames, prevIDs, prevLambda, prevLambdaLocals
 	}()
+
+	captures := g.lambdaCaptureInfos(expr)
+	if len(captures) > 0 {
+		g.activeLambda = make(map[symbols.SymbolID]typeinfo.LambdaCapture, len(captures))
+		g.activeLambdaLocals = make(map[int]typeinfo.LambdaCapture, len(captures))
+		for _, capture := range captures {
+			if capture.Symbol == nil {
+				continue
+			}
+			g.activeLambda[capture.Symbol.ID] = capture
+			if id, ok := g.ensureLocalID(capture.Symbol); ok {
+				g.activeLambdaLocals[id] = capture
+			}
+		}
+	}
 
 	fn := &Func{
 		Name:       g.nextLambdaName(),
@@ -453,7 +470,6 @@ func (g *generator) generateLambdaFunc(expr *ast.LambdaExpr, fnType *typeinfo.Fu
 		Location:   expr.Location,
 	}
 	g.lambdaNames[expr] = fn.Name
-	captures := g.lambdaCaptureSymbols(expr)
 	if len(captures) > 0 {
 		closure := &Closure{
 			Name:       fn.Name + "__closure",
@@ -463,50 +479,70 @@ func (g *generator) generateLambdaFunc(expr *ast.LambdaExpr, fnType *typeinfo.Fu
 			LambdaExpr: expr,
 		}
 		for _, captured := range captures {
-			if captured == nil {
+			sym := captured.Symbol
+			if sym == nil {
 				continue
 			}
 			captureType := typeinfo.Type(typeinfo.UnknownType{})
 			if g.types != nil {
-				if typ := g.types.Symbols[captured.ID]; typ != nil {
+				if typ := g.types.Symbols[sym.ID]; typ != nil {
 					captureType = typ
 				}
 			}
+			if captured.ByRef {
+				captureType = &typeinfo.RefType{Mutable: captured.Mutable, Inner: captureType}
+			}
 			localID := -1
-			if id, ok := g.ensureLocalID(captured); ok {
+			if id, ok := g.ensureLocalID(sym); ok {
 				localID = id
 			}
+			isMutable := false
+			if captured.ByRef {
+				isMutable = captured.Mutable
+			} else {
+				isMutable = expr.IsMove && g.symbolMutableForLambdaCapture(sym)
+			}
 			closure.Captures = append(closure.Captures, &Param{
-				Name:      g.mangleLocal(captured),
+				Name:      g.mangleLocal(sym),
 				LocalID:   localID,
 				Type:      captureType,
-				IsMutable: expr.IsMove && g.symbolMutableForLambdaCapture(captured),
-				Location:  captured.Location,
+				IsMutable: isMutable,
+				Location:  sym.Location,
 			})
 		}
 		g.synthClosures = append(g.synthClosures, closure)
 	}
 	fn.Params = make([]*Param, 0, len(captures)+len(expr.Params))
 	for _, captured := range captures {
+		sym := captured.Symbol
 		captureType := typeinfo.Type(typeinfo.UnknownType{})
-		if g.types != nil && captured != nil {
-			if typ := g.types.Symbols[captured.ID]; typ != nil {
+		if g.types != nil && sym != nil {
+			if typ := g.types.Symbols[sym.ID]; typ != nil {
 				captureType = typ
 			}
 		}
+		if captured.ByRef {
+			captureType = &typeinfo.RefType{Mutable: captured.Mutable, Inner: captureType}
+		}
 		name := ""
 		localID := -1
-		if captured != nil {
-			name = g.mangleLocal(captured)
-			if id, ok := g.ensureLocalID(captured); ok {
+		if sym != nil {
+			name = g.mangleLocal(sym)
+			if id, ok := g.ensureLocalID(sym); ok {
 				localID = id
 			}
+		}
+		isMutable := false
+		if captured.ByRef {
+			isMutable = captured.Mutable
+		} else {
+			isMutable = expr.IsMove && sym != nil && g.symbolMutableForLambdaCapture(sym)
 		}
 		fn.Params = append(fn.Params, &Param{
 			Name:      name,
 			LocalID:   localID,
 			Type:      captureType,
-			IsMutable: expr.IsMove && captured != nil && g.symbolMutableForLambdaCapture(captured),
+			IsMutable: isMutable,
 			Location:  expr.Location,
 		})
 	}
@@ -590,7 +626,7 @@ func (g *generator) symbolMutableForLambdaCapture(sym *symbols.Symbol) bool {
 	}
 }
 
-func (g *generator) lambdaCaptureSymbols(expr *ast.LambdaExpr) []*symbols.Symbol {
+func (g *generator) lambdaCaptureInfos(expr *ast.LambdaExpr) []typeinfo.LambdaCapture {
 	if g == nil || g.types == nil || expr == nil {
 		return nil
 	}
@@ -602,12 +638,13 @@ func (g *generator) lambdaCaptureSymbols(expr *ast.LambdaExpr) []*symbols.Symbol
 }
 
 func (g *generator) capturedArgsForLambda(expr *ast.LambdaExpr) []Expr {
-	captures := g.lambdaCaptureSymbols(expr)
+	captures := g.lambdaCaptureInfos(expr)
 	if len(captures) == 0 {
 		return nil
 	}
 	args := make([]Expr, 0, len(captures))
-	for _, sym := range captures {
+	for _, capture := range captures {
+		sym := capture.Symbol
 		if sym == nil {
 			continue
 		}
@@ -625,8 +662,19 @@ func (g *generator) capturedArgsForLambda(expr *ast.LambdaExpr) []Expr {
 				typ = symType
 			}
 		}
-		arg := &Ident{Path: path, LocalID: localID}
-		arg.ExprType, arg.Location, arg.Source = typ, sym.Location, nil
+		base := &Ident{Path: path, LocalID: localID}
+		base.ExprType, base.Location, base.Source = typ, sym.Location, nil
+		if !capture.ByRef {
+			args = append(args, base)
+			continue
+		}
+		refType := &typeinfo.RefType{Mutable: capture.Mutable, Inner: typ}
+		op := "&"
+		if capture.Mutable {
+			op = "&mut"
+		}
+		arg := &PrefixExpr{Op: op, Right: base}
+		arg.ExprType, arg.Location, arg.Source = refType, sym.Location, nil
 		args = append(args, arg)
 	}
 	return args
@@ -1004,6 +1052,25 @@ func (g *generator) generateExpr(expr ast.Expr) Expr {
 				path[0] = g.mangleLocal(sym)
 				if id, ok := g.ensureLocalID(sym); ok {
 					localID = id
+				}
+				if g.activeLambdaLocals != nil {
+					if capture, ok := g.activeLambdaLocals[localID]; ok && capture.ByRef {
+						refType := &typeinfo.RefType{Mutable: capture.Mutable, Inner: typ}
+						inner := &Ident{Path: path, LocalID: localID}
+						inner.ExprType, inner.Location, inner.Source = refType, e.Location, nil
+						out := &PrefixExpr{Op: "*", Right: inner}
+						out.ExprType, out.Location, out.Source = typ, e.Location, e
+						return out
+					}
+				} else if g.activeLambda != nil {
+					if capture, ok := g.activeLambda[sym.ID]; ok && capture.ByRef {
+						refType := &typeinfo.RefType{Mutable: capture.Mutable, Inner: typ}
+						inner := &Ident{Path: path, LocalID: localID}
+						inner.ExprType, inner.Location, inner.Source = refType, e.Location, nil
+						out := &PrefixExpr{Op: "*", Right: inner}
+						out.ExprType, out.Location, out.Source = typ, e.Location, e
+						return out
+					}
 				}
 			}
 		}

--- a/internal/ir/hir/generate.go
+++ b/internal/ir/hir/generate.go
@@ -450,7 +450,31 @@ func (g *generator) generateLambdaFunc(expr *ast.LambdaExpr, fnType *typeinfo.Fu
 		Location:   expr.Location,
 	}
 	g.lambdaNames[expr] = fn.Name
-	fn.Params = make([]*Param, 0, len(expr.Params))
+	captures := g.lambdaCaptureSymbols(expr)
+	fn.Params = make([]*Param, 0, len(captures)+len(expr.Params))
+	for _, captured := range captures {
+		captureType := typeinfo.Type(typeinfo.UnknownType{})
+		if g.types != nil && captured != nil {
+			if typ := g.types.Symbols[captured.ID]; typ != nil {
+				captureType = typ
+			}
+		}
+		name := ""
+		localID := -1
+		if captured != nil {
+			name = g.mangleLocal(captured)
+			if id, ok := g.ensureLocalID(captured); ok {
+				localID = id
+			}
+		}
+		fn.Params = append(fn.Params, &Param{
+			Name:      name,
+			LocalID:   localID,
+			Type:      captureType,
+			IsMutable: expr.IsMove && captured != nil && g.symbolMutableForLambdaCapture(captured),
+			Location:  expr.Location,
+		})
+	}
 	for i, param := range expr.Params {
 		paramType := typeinfo.Type(typeinfo.UnknownType{})
 		if i < len(fnType.Params) && fnType.Params[i].Type != nil {
@@ -468,44 +492,109 @@ func (g *generator) generateLambdaFunc(expr *ast.LambdaExpr, fnType *typeinfo.Fu
 	return fn
 }
 
-func (g *generator) functionAliasName(sym *symbols.Symbol) (string, bool) {
+func (g *generator) functionAlias(sym *symbols.Symbol) (string, *ast.LambdaExpr, bool) {
 	if g == nil || sym == nil {
-		return "", false
+		return "", nil, false
 	}
 	switch node := sym.Node.(type) {
 	case *ast.LetStmt:
 		if node == nil || node.IsMut {
-			return "", false
+			return "", nil, false
 		}
 		lambda, ok := node.Value.(*ast.LambdaExpr)
 		if !ok || lambda == nil {
-			return "", false
+			return "", nil, false
 		}
-		return g.lambdaName(lambda)
+		name, ok := g.lambdaName(lambda)
+		return name, lambda, ok
 	case *ast.ConstStmt:
 		lambda, ok := node.Value.(*ast.LambdaExpr)
 		if !ok || lambda == nil {
-			return "", false
+			return "", nil, false
 		}
-		return g.lambdaName(lambda)
+		name, ok := g.lambdaName(lambda)
+		return name, lambda, ok
 	case *ast.LetDecl:
 		if node == nil || node.IsMut {
-			return "", false
+			return "", nil, false
 		}
 		lambda, ok := node.Value.(*ast.LambdaExpr)
 		if !ok || lambda == nil {
-			return "", false
+			return "", nil, false
 		}
-		return g.lambdaName(lambda)
+		name, ok := g.lambdaName(lambda)
+		return name, lambda, ok
 	case *ast.ConstDecl:
 		lambda, ok := node.Value.(*ast.LambdaExpr)
 		if !ok || lambda == nil {
-			return "", false
+			return "", nil, false
 		}
-		return g.lambdaName(lambda)
+		name, ok := g.lambdaName(lambda)
+		return name, lambda, ok
 	default:
-		return "", false
+		return "", nil, false
 	}
+}
+
+func (g *generator) symbolMutableForLambdaCapture(sym *symbols.Symbol) bool {
+	if sym == nil {
+		return false
+	}
+	if sym.Kind == symbols.SymbolConst {
+		return false
+	}
+	switch node := sym.Node.(type) {
+	case *ast.LetDecl:
+		return node != nil && node.IsMut
+	case *ast.LetStmt:
+		return node != nil && node.IsMut
+	case *ast.ConstDecl, *ast.ConstStmt:
+		return false
+	default:
+		return sym.Flags.Mutable()
+	}
+}
+
+func (g *generator) lambdaCaptureSymbols(expr *ast.LambdaExpr) []*symbols.Symbol {
+	if g == nil || g.types == nil || expr == nil {
+		return nil
+	}
+	captures, ok := g.types.LookupLambdaCaptures(expr)
+	if !ok || len(captures) == 0 {
+		return nil
+	}
+	return captures
+}
+
+func (g *generator) capturedArgsForLambda(expr *ast.LambdaExpr) []Expr {
+	captures := g.lambdaCaptureSymbols(expr)
+	if len(captures) == 0 {
+		return nil
+	}
+	args := make([]Expr, 0, len(captures))
+	for _, sym := range captures {
+		if sym == nil {
+			continue
+		}
+		path := []string{sym.Name}
+		localID := -1
+		if g.inFunction && g.isFunctionLocal(sym) {
+			path[0] = g.mangleLocal(sym)
+			if id, ok := g.ensureLocalID(sym); ok {
+				localID = id
+			}
+		}
+		typ := typeinfo.Type(typeinfo.UnknownType{})
+		if g.types != nil {
+			if symType := g.types.Symbols[sym.ID]; symType != nil {
+				typ = symType
+			}
+		}
+		arg := &Ident{Path: path, LocalID: localID}
+		arg.ExprType, arg.Location, arg.Source = typ, sym.Location, nil
+		args = append(args, arg)
+	}
+	return args
 }
 
 func (g *generator) generateLambdaBody(expr *ast.LambdaExpr, result typeinfo.Type) *BlockStmt {
@@ -850,7 +939,7 @@ func (g *generator) generateExpr(expr ast.Expr) Expr {
 		return out
 	case *ast.Ident:
 		if sym, ok := g.localSymbol(e); ok {
-			if alias, ok := g.functionAliasName(sym); ok {
+			if alias, _, ok := g.functionAlias(sym); ok {
 				out := &Ident{Path: []string{alias}, LocalID: -1}
 				out.ExprType, out.Location, out.Source = typ, e.Location, nil
 				return out
@@ -927,11 +1016,20 @@ func (g *generator) generateExpr(expr ast.Expr) Expr {
 			args = expanded
 		}
 		calleeType, _ := exprType(g.types, e.Callee).(*typeinfo.FuncType)
-		out := &CallExpr{Callee: g.generateExpr(e.Callee), Args: make([]Expr, 0, len(args))}
+		captureArgs := make([]Expr, 0)
+		if ident, ok := e.Callee.(*ast.Ident); ok && ident != nil {
+			if sym, ok := g.localSymbol(ident); ok && sym != nil {
+				if _, lambdaExpr, ok := g.functionAlias(sym); ok && lambdaExpr != nil {
+					captureArgs = g.capturedArgsForLambda(lambdaExpr)
+				}
+			}
+		}
+		out := &CallExpr{Callee: g.generateExpr(e.Callee), Args: make([]Expr, 0, len(captureArgs)+len(args))}
 		if recv, ok := g.types.LookupMethodReceiver(e); ok {
 			out.MethodReceiver = recv
 		}
 		out.ExprType, out.Location, out.Source = typ, e.Location, e
+		out.Args = append(out.Args, captureArgs...)
 		for i, arg := range args {
 			target := typeinfo.Type(nil)
 			if calleeType != nil && len(calleeType.Params) != 0 {

--- a/internal/ir/hir/generate.go
+++ b/internal/ir/hir/generate.go
@@ -632,6 +632,23 @@ func (g *generator) capturedArgsForLambda(expr *ast.LambdaExpr) []Expr {
 	return args
 }
 
+func (g *generator) closureLitForLambda(expr *ast.LambdaExpr, typ typeinfo.Type, loc source.Location) Expr {
+	if expr == nil {
+		return nil
+	}
+	name, ok := g.lambdaName(expr)
+	if !ok || name == "" {
+		return nil
+	}
+	out := &ClosureLit{
+		Name:     name + "__closure",
+		FuncName: name,
+		Captures: g.capturedArgsForLambda(expr),
+	}
+	out.ExprType, out.Location, out.Source = typ, loc, nil
+	return out
+}
+
 func (g *generator) generateLambdaBody(expr *ast.LambdaExpr, result typeinfo.Type) *BlockStmt {
 	if expr == nil {
 		return nil
@@ -974,10 +991,10 @@ func (g *generator) generateExpr(expr ast.Expr) Expr {
 		return out
 	case *ast.Ident:
 		if sym, ok := g.localSymbol(e); ok {
-			if alias, _, ok := g.functionAlias(sym); ok {
-				out := &Ident{Path: []string{alias}, LocalID: -1}
-				out.ExprType, out.Location, out.Source = typ, e.Location, nil
-				return out
+			if _, lambda, ok := g.functionAlias(sym); ok && lambda != nil {
+				if out := g.closureLitForLambda(lambda, typ, e.Location); out != nil {
+					return out
+				}
 			}
 		}
 		path := append([]string{}, e.Path...)
@@ -1051,20 +1068,11 @@ func (g *generator) generateExpr(expr ast.Expr) Expr {
 			args = expanded
 		}
 		calleeType, _ := exprType(g.types, e.Callee).(*typeinfo.FuncType)
-		captureArgs := make([]Expr, 0)
-		if ident, ok := e.Callee.(*ast.Ident); ok && ident != nil {
-			if sym, ok := g.localSymbol(ident); ok && sym != nil {
-				if _, lambdaExpr, ok := g.functionAlias(sym); ok && lambdaExpr != nil {
-					captureArgs = g.capturedArgsForLambda(lambdaExpr)
-				}
-			}
-		}
-		out := &CallExpr{Callee: g.generateExpr(e.Callee), Args: make([]Expr, 0, len(captureArgs)+len(args))}
+		out := &CallExpr{Callee: g.generateExpr(e.Callee), Args: make([]Expr, 0, len(args))}
 		if recv, ok := g.types.LookupMethodReceiver(e); ok {
 			out.MethodReceiver = recv
 		}
 		out.ExprType, out.Location, out.Source = typ, e.Location, e
-		out.Args = append(out.Args, captureArgs...)
 		for i, arg := range args {
 			target := typeinfo.Type(nil)
 			if calleeType != nil && len(calleeType.Params) != 0 {
@@ -1220,9 +1228,7 @@ func (g *generator) generateExpr(expr ast.Expr) Expr {
 			return nil
 		}
 		g.synthFuncs = append(g.synthFuncs, fn)
-		out := &Ident{Path: []string{fn.Name}, LocalID: -1}
-		out.ExprType, out.Location, out.Source = typ, e.Location, nil
-		return out
+		return g.closureLitForLambda(e, typ, e.Location)
 	default:
 		return nil
 	}

--- a/internal/ir/hir/generate_test.go
+++ b/internal/ir/hir/generate_test.go
@@ -175,12 +175,12 @@ fn main() -> i32 {
 	if !ok {
 		t.Fatalf("expected lambda call, got %T", ret.Value)
 	}
-	callee, ok := call.Callee.(*hir.Ident)
+	callee, ok := call.Callee.(*hir.ClosureLit)
 	if !ok {
-		t.Fatalf("expected lambda callee ident, got %T", call.Callee)
+		t.Fatalf("expected lambda callee closure, got %T", call.Callee)
 	}
-	if callee.Path[0] != lambdaFn.Name {
-		t.Fatalf("expected lambda callee %q, got %#v", lambdaFn.Name, callee.Path)
+	if callee.FuncName != lambdaFn.Name || len(callee.Captures) != 0 {
+		t.Fatalf("expected non-capturing closure for %q, got %#v", lambdaFn.Name, callee)
 	}
 }
 
@@ -232,8 +232,15 @@ fn main() -> i32 {
 	if !ok {
 		t.Fatalf("expected call expr, got %T", ret.Value)
 	}
-	if len(call.Args) != 2 {
-		t.Fatalf("expected hidden capture + explicit argument in call, got %#v", call.Args)
+	if len(call.Args) != 1 {
+		t.Fatalf("expected only explicit argument in call, got %#v", call.Args)
+	}
+	callee, ok := call.Callee.(*hir.ClosureLit)
+	if !ok {
+		t.Fatalf("expected closure callee, got %T", call.Callee)
+	}
+	if callee.FuncName != lambdaFn.Name || len(callee.Captures) != 1 {
+		t.Fatalf("expected single-capture closure for %q, got %#v", lambdaFn.Name, callee)
 	}
 	if len(result.Entry.HIR.Closures) != 1 {
 		t.Fatalf("expected one closure env descriptor, got %#v", result.Entry.HIR.Closures)

--- a/internal/ir/hir/generate_test.go
+++ b/internal/ir/hir/generate_test.go
@@ -235,6 +235,16 @@ fn main() -> i32 {
 	if len(call.Args) != 2 {
 		t.Fatalf("expected hidden capture + explicit argument in call, got %#v", call.Args)
 	}
+	if len(result.Entry.HIR.Closures) != 1 {
+		t.Fatalf("expected one closure env descriptor, got %#v", result.Entry.HIR.Closures)
+	}
+	closure := result.Entry.HIR.Closures[0]
+	if closure == nil || closure.FuncName != lambdaFn.Name {
+		t.Fatalf("expected closure metadata for %q, got %#v", lambdaFn.Name, closure)
+	}
+	if len(closure.Captures) != 1 || closure.Captures[0] == nil || closure.Captures[0].Name != "x" {
+		t.Fatalf("expected single capture x in closure metadata, got %#v", closure)
+	}
 }
 
 func TestPipelineFoldsEarlyConstInitializersInHIR(t *testing.T) {

--- a/internal/ir/hir/generate_test.go
+++ b/internal/ir/hir/generate_test.go
@@ -184,6 +184,59 @@ fn main() -> i32 {
 	}
 }
 
+func TestPipelineGeneratesCapturedLambdaCallInHIR(t *testing.T) {
+	root := t.TempDir()
+	mustWriteHIR(t, filepath.Join(root, "main.fer"), `
+fn main() -> i32 {
+    let x = 5
+    let addx = (y: i32) => x + y
+    return addx(2)
+}
+`)
+
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	if result.Entry == nil || result.Entry.HIR == nil {
+		t.Fatal("expected HIR module")
+	}
+	var lambdaFn *hir.Func
+	var mainFn *hir.Func
+	for _, fn := range result.Entry.HIR.Functions {
+		if fn == nil {
+			continue
+		}
+		if fn.Name == "main" {
+			mainFn = fn
+			continue
+		}
+		if strings.HasPrefix(fn.Name, "__lambda") {
+			lambdaFn = fn
+		}
+	}
+	if lambdaFn == nil {
+		t.Fatalf("expected synthetic lambda function, got %#v", result.Entry.HIR.Functions)
+	}
+	if len(lambdaFn.Params) != 2 {
+		t.Fatalf("expected capture + explicit lambda params, got %#v", lambdaFn.Params)
+	}
+	if mainFn == nil {
+		t.Fatal("expected main function")
+	}
+	ret, ok := mainFn.Body.Stmts[len(mainFn.Body.Stmts)-1].(*hir.ReturnStmt)
+	if !ok {
+		t.Fatalf("expected return stmt, got %T", mainFn.Body.Stmts[len(mainFn.Body.Stmts)-1])
+	}
+	call, ok := ret.Value.(*hir.CallExpr)
+	if !ok {
+		t.Fatalf("expected call expr, got %T", ret.Value)
+	}
+	if len(call.Args) != 2 {
+		t.Fatalf("expected hidden capture + explicit argument in call, got %#v", call.Args)
+	}
+}
+
 func TestPipelineFoldsEarlyConstInitializersInHIR(t *testing.T) {
 	root := t.TempDir()
 	mustWriteHIR(t, filepath.Join(root, "main.fer"), `

--- a/internal/ir/hir/lower.go
+++ b/internal/ir/hir/lower.go
@@ -539,6 +539,16 @@ func (l *lowerer) lowerExpr(expr Expr) ([]Stmt, Expr) {
 			out.Args[i] = lowered
 		}
 		return prelude, &out
+	case *ClosureLit:
+		out := *e
+		out.Captures = append([]Expr(nil), e.Captures...)
+		var prelude []Stmt
+		for i, capture := range out.Captures {
+			capturePrelude, lowered := l.lowerExpr(capture)
+			prelude = append(prelude, capturePrelude...)
+			out.Captures[i] = lowered
+		}
+		return prelude, &out
 	case *SelectorExpr:
 		prelude, left := l.lowerExpr(e.Left)
 		out := *e
@@ -1054,6 +1064,13 @@ func (l *lowerer) rewriteExprIdents(expr Expr, fromName string, fromID int, toNa
 		out.Args = append([]Expr(nil), e.Args...)
 		for i, arg := range out.Args {
 			out.Args[i] = l.rewriteExprIdents(arg, fromName, fromID, toName, toID)
+		}
+		return &out
+	case *ClosureLit:
+		out := *e
+		out.Captures = append([]Expr(nil), e.Captures...)
+		for i, capture := range out.Captures {
+			out.Captures[i] = l.rewriteExprIdents(capture, fromName, fromID, toName, toID)
 		}
 		return &out
 	case *SelectorExpr:

--- a/internal/ir/hir/module.go
+++ b/internal/ir/hir/module.go
@@ -13,7 +13,16 @@ type Module struct {
 	Source     *ast.Module
 	Types      []*TypeDecl
 	Globals    []*Global
+	Closures   []*Closure
 	Functions  []*Func
+}
+
+type Closure struct {
+	Name       string
+	FuncName   string
+	Captures   []*Param
+	Location   source.Location
+	LambdaExpr *ast.LambdaExpr
 }
 
 type TypeDecl struct {

--- a/internal/ir/hir/specialize.go
+++ b/internal/ir/hir/specialize.go
@@ -576,6 +576,14 @@ func (s *specializer) cloneExpr(expr Expr, bindings map[*typeinfo.TypeParam]type
 		}
 		out.Callee = clonedCallee
 		return &out
+	case *ClosureLit:
+		out := *ex
+		out.ExprType = s.substituteType(ex.Type(), bindings)
+		out.Captures = make([]Expr, 0, len(ex.Captures))
+		for _, capture := range ex.Captures {
+			out.Captures = append(out.Captures, s.cloneExpr(capture, bindings))
+		}
+		return &out
 	case *SelectorExpr:
 		out := *ex
 		out.Left = s.cloneExpr(ex.Left, bindings)

--- a/internal/ir/mir/debug.go
+++ b/internal/ir/mir/debug.go
@@ -57,8 +57,36 @@ func DebugModule(mod *Module) any {
 		"key":         mod.Key,
 		"import_path": mod.ImportPath,
 		"globals":     globals,
+		"closures":    debugClosures(mod.Closures),
 		"functions":   funcs,
 	}
+}
+
+func debugClosures(closures []*Closure) []any {
+	out := make([]any, 0, len(closures))
+	for _, closure := range closures {
+		if closure == nil {
+			continue
+		}
+		captures := make([]any, 0, len(closure.Captures))
+		for _, capture := range closure.Captures {
+			if capture == nil {
+				continue
+			}
+			captures = append(captures, map[string]any{
+				"name":     capture.Name,
+				"local_id": capture.LocalID,
+				"type":     typeString(capture.Type),
+				"mutable":  capture.IsMutable,
+			})
+		}
+		out = append(out, map[string]any{
+			"name":     closure.Name,
+			"func":     closure.FuncName,
+			"captures": captures,
+		})
+	}
+	return out
 }
 
 func debugInstr(instr Instr) any {
@@ -145,6 +173,12 @@ func debugValue(value Value) any {
 			args = append(args, debugValue(arg))
 		}
 		return map[string]any{"kind": "call", "callee": debugValue(v.Callee), "args": args, "type": typeString(v.Type())}
+	case *ClosureValue:
+		captures := make([]any, 0, len(v.Captures))
+		for _, capture := range v.Captures {
+			captures = append(captures, debugValue(capture))
+		}
+		return map[string]any{"kind": "closure", "name": v.Name, "func": v.FuncName, "captures": captures, "type": typeString(v.Type())}
 	case *FieldLoadValue:
 		return map[string]any{"kind": "field_load", "base": debugValue(v.Base), "field_index": v.FieldIndex, "type": typeString(v.Type())}
 	case *FieldValue:

--- a/internal/ir/mir/format.go
+++ b/internal/ir/mir/format.go
@@ -22,7 +22,7 @@ func FormatModule(mod *Module) string {
 		b.WriteString(formatTypeDecl(decl))
 		b.WriteByte('\n')
 	}
-	if len(mod.Types) > 0 && (len(mod.Globals) > 0 || len(mod.Functions) > 0) {
+	if len(mod.Types) > 0 && (len(mod.Globals) > 0 || len(mod.Closures) > 0 || len(mod.Functions) > 0) {
 		b.WriteByte('\n')
 	}
 	if len(mod.Globals) > 0 {
@@ -34,7 +34,26 @@ func FormatModule(mod *Module) string {
 			fmt.Fprintf(&b, "    %s %s: %s = %s\n", globalKeyword(global), global.Name, renderType(global.Type), formatValue(global.Init))
 		}
 	}
-	if len(mod.Globals) > 0 && len(mod.Functions) > 0 {
+	if len(mod.Globals) > 0 && (len(mod.Closures) > 0 || len(mod.Functions) > 0) {
+		b.WriteByte('\n')
+	}
+	if len(mod.Closures) > 0 {
+		b.WriteString("closures:\n")
+		for _, closure := range mod.Closures {
+			if closure == nil {
+				continue
+			}
+			fmt.Fprintf(&b, "    %s -> %s(", closure.Name, closure.FuncName)
+			for i, capture := range closure.Captures {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				b.WriteString(formatParam(capture))
+			}
+			b.WriteString(")\n")
+		}
+	}
+	if len(mod.Closures) > 0 && len(mod.Functions) > 0 {
 		b.WriteByte('\n')
 	}
 	for i, fn := range mod.Functions {
@@ -302,6 +321,12 @@ func formatValue(value Value) string {
 			args = append(args, formatValue(arg))
 		}
 		return fmt.Sprintf("%s(%s)", wrapValue(v.Callee), strings.Join(args, ", "))
+	case *ClosureValue:
+		captures := make([]string, 0, len(v.Captures))
+		for _, capture := range v.Captures {
+			captures = append(captures, formatValue(capture))
+		}
+		return fmt.Sprintf("closure %s[%s]", v.FuncName, strings.Join(captures, ", "))
 	case *FieldLoadValue:
 		return fmt.Sprintf("field %s %d", wrapValue(v.Base), v.FieldIndex)
 	case *FieldValue:
@@ -441,7 +466,7 @@ func formatLocalRef(fn *Function, id int) string {
 
 func wrapValue(value Value) string {
 	switch value.(type) {
-	case *NameValue, *LocalValue, *NumberValue, *BoolValue, *StringValue, *NoneValue, *FieldLoadValue, *FieldValue, *CallValue, *CompositeValue:
+	case *NameValue, *LocalValue, *NumberValue, *BoolValue, *StringValue, *NoneValue, *FieldLoadValue, *FieldValue, *CallValue, *CompositeValue, *ClosureValue:
 		return formatValue(value)
 	default:
 		return "(" + formatValue(value) + ")"

--- a/internal/ir/mir/lower.go
+++ b/internal/ir/mir/lower.go
@@ -342,6 +342,19 @@ func lowerAssignableTarget(lowerCtx *lowerContext, expr hir.Expr) Place {
 	if expr == nil {
 		return nil
 	}
+	ident, ok := expr.(*hir.Ident)
+	if !ok {
+		return nil
+	}
+	if ident.LocalID >= 0 {
+		return &DerefPlace{
+			basePlace: basePlace{Location: expr.Loc()},
+			Pointer: &AddrOfValue{
+				baseValue: baseValue{Location: expr.Loc(), ExprType: &typeinfo.PointerType{Inner: expr.Type()}},
+				Source:    lowerAddrSource(lowerCtx, ident),
+			},
+		}
+	}
 	if resolved := lowerResolvedName(lowerCtx, expr.SourceExpr(), expr.Loc(), expr.Type()); resolved != nil {
 		return &DerefPlace{
 			basePlace: basePlace{Location: expr.Loc()},

--- a/internal/ir/mir/lower.go
+++ b/internal/ir/mir/lower.go
@@ -36,6 +36,7 @@ func LowerModule(cfgMod *cfg.Module, hirMod *hir.Module, bindings *binding.Modul
 		FilePath:   hirMod.FilePath,
 		Types:      make([]*TypeDecl, 0, len(hirMod.Types)),
 		Globals:    make([]*Global, 0, len(hirMod.Globals)),
+		Closures:   make([]*Closure, 0, len(hirMod.Closures)),
 		Functions:  make([]*Function, 0, len(cfgMod.Functions)),
 	}
 	for _, decl := range hirMod.Types {
@@ -43,6 +44,30 @@ func LowerModule(cfgMod *cfg.Module, hirMod *hir.Module, bindings *binding.Modul
 	}
 	for _, global := range hirMod.Globals {
 		out.Globals = append(out.Globals, lowerGlobal(global, bindings, globalConsts, hirMod.ImportPath, lookupMethod, structTypes))
+	}
+	for _, closure := range hirMod.Closures {
+		if closure == nil {
+			continue
+		}
+		entry := &Closure{
+			Name:     closure.Name,
+			FuncName: closure.FuncName,
+			Location: closure.Location,
+			Captures: make([]*Param, 0, len(closure.Captures)),
+		}
+		for _, capture := range closure.Captures {
+			if capture == nil {
+				continue
+			}
+			entry.Captures = append(entry.Captures, &Param{
+				Name:      capture.Name,
+				LocalID:   capture.LocalID,
+				Type:      capture.Type,
+				IsMutable: capture.IsMutable,
+				Location:  capture.Location,
+			})
+		}
+		out.Closures = append(out.Closures, entry)
 	}
 	for _, fn := range cfgMod.Functions {
 		out.Functions = append(out.Functions, lowerFunction(fn, bindings, globalConsts, hirMod.ImportPath, lookupMethod, structTypes))
@@ -559,6 +584,17 @@ func lowerValue(lowerCtx *lowerContext, expr hir.Expr) Value {
 		}
 		out := &CallValue{baseValue: baseValue{Location: e.Loc(), ExprType: e.Type()}, Callee: lowerValue(lowerCtx, e.Callee), Args: make([]Value, 0, len(e.Args))}
 		out.Args = append(out.Args, lowerCallArgs(lowerCtx, e.Loc(), e.Args, fnType, stringifyAnyArgs)...)
+		return out
+	case *hir.ClosureLit:
+		out := &ClosureValue{
+			baseValue: baseValue{Location: e.Loc(), ExprType: e.Type()},
+			Name:      e.Name,
+			FuncName:  e.FuncName,
+			Captures:  make([]Value, 0, len(e.Captures)),
+		}
+		for _, capture := range e.Captures {
+			out.Captures = append(out.Captures, lowerValue(lowerCtx, capture))
+		}
 		return out
 	case *hir.SelectorExpr:
 		if resolved := lowerResolvedName(lowerCtx, e.SourceExpr(), e.Loc(), e.Type()); resolved != nil {

--- a/internal/ir/mir/lower_test.go
+++ b/internal/ir/mir/lower_test.go
@@ -1734,7 +1734,7 @@ fn main() -> i32 {
 		t.Fatalf("expected synthetic lambda MIR function, got %#v", result.Entry.MIR.Functions)
 	}
 	text := mir.FormatModule(result.Entry.MIR)
-	if !strings.Contains(text, "closure "+lambdaFn.Name+"[5]") {
+	if !strings.Contains(text, "addr_of x") || !strings.Contains(text, "closure "+lambdaFn.Name+"[_t") {
 		t.Fatalf("expected captured closure value in MIR dump, got:\n%s", text)
 	}
 	if !strings.Contains(text, "(2)") {

--- a/internal/ir/mir/lower_test.go
+++ b/internal/ir/mir/lower_test.go
@@ -1695,8 +1695,11 @@ fn main() -> i32 {
 	if !strings.Contains(text, "fn "+lambdaFn.Name) {
 		t.Fatalf("expected synthetic lambda function in MIR dump, got:\n%s", text)
 	}
-	if !strings.Contains(text, "= "+lambdaFn.Name+"(") {
-		t.Fatalf("expected main to call synthetic lambda function in MIR dump, got:\n%s", text)
+	if !strings.Contains(text, "closure "+lambdaFn.Name+"[") {
+		t.Fatalf("expected main to materialize lambda closure in MIR dump, got:\n%s", text)
+	}
+	if !strings.Contains(text, "(1, 2)") {
+		t.Fatalf("expected main to call lambda closure in MIR dump, got:\n%s", text)
 	}
 }
 
@@ -1731,11 +1734,11 @@ fn main() -> i32 {
 		t.Fatalf("expected synthetic lambda MIR function, got %#v", result.Entry.MIR.Functions)
 	}
 	text := mir.FormatModule(result.Entry.MIR)
-	if !strings.Contains(text, "= "+lambdaFn.Name+"(") {
-		t.Fatalf("expected call to synthetic captured lambda in MIR dump, got:\n%s", text)
+	if !strings.Contains(text, "closure "+lambdaFn.Name+"[5]") {
+		t.Fatalf("expected captured closure value in MIR dump, got:\n%s", text)
 	}
-	if !strings.Contains(text, "= "+lambdaFn.Name+"(5, 2") {
-		t.Fatalf("expected captured arg to be threaded into lambda call, got:\n%s", text)
+	if !strings.Contains(text, "(2)") {
+		t.Fatalf("expected call through captured closure in MIR dump, got:\n%s", text)
 	}
 }
 

--- a/internal/ir/mir/lower_test.go
+++ b/internal/ir/mir/lower_test.go
@@ -1700,6 +1700,45 @@ fn main() -> i32 {
 	}
 }
 
+func TestPipelineLowersCapturedLambdaCallToMIR(t *testing.T) {
+	root := t.TempDir()
+	mustWriteIR(t, filepath.Join(root, "main.fer"), `
+fn main() -> i32 {
+    let x = 5
+    let addx = (y: i32) => x + y
+    return addx(2)
+}
+`)
+
+	result := compiler.ParsePath(filepath.Join(root, "main.fer"))
+	if result.Diagnostics.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics.Diagnostics())
+	}
+	if result.Entry == nil || result.Entry.MIR == nil {
+		t.Fatal("expected MIR module")
+	}
+	var lambdaFn *mir.Function
+	for _, fn := range result.Entry.MIR.Functions {
+		if fn == nil {
+			continue
+		}
+		if strings.HasPrefix(fn.Name, "__lambda") {
+			lambdaFn = fn
+			break
+		}
+	}
+	if lambdaFn == nil {
+		t.Fatalf("expected synthetic lambda MIR function, got %#v", result.Entry.MIR.Functions)
+	}
+	text := mir.FormatModule(result.Entry.MIR)
+	if !strings.Contains(text, "= "+lambdaFn.Name+"(") {
+		t.Fatalf("expected call to synthetic captured lambda in MIR dump, got:\n%s", text)
+	}
+	if !strings.Contains(text, "= "+lambdaFn.Name+"(5, 2") {
+		t.Fatalf("expected captured arg to be threaded into lambda call, got:\n%s", text)
+	}
+}
+
 func hasCallNamed(call *mir.CallValue, name string) bool {
 	if call == nil {
 		return false

--- a/internal/ir/mir/model.go
+++ b/internal/ir/mir/model.go
@@ -11,7 +11,15 @@ type Module struct {
 	FilePath   string
 	Types      []*TypeDecl
 	Globals    []*Global
+	Closures   []*Closure
 	Functions  []*Function
+}
+
+type Closure struct {
+	Name     string
+	FuncName string
+	Captures []*Param
+	Location source.Location
 }
 
 type TypeDecl struct {
@@ -257,6 +265,15 @@ type CallValue struct {
 }
 
 func (*CallValue) valueNode() {}
+
+type ClosureValue struct {
+	baseValue
+	Name     string
+	FuncName string
+	Captures []Value
+}
+
+func (*ClosureValue) valueNode() {}
 
 type FieldLoadValue struct {
 	baseValue

--- a/internal/ir/mir/normalize.go
+++ b/internal/ir/mir/normalize.go
@@ -53,6 +53,11 @@ func (n *normalizer) normalizeGlobalValue(value Value) Value {
 			v.Args[i] = n.normalizeGlobalValue(arg)
 		}
 		return v
+	case *ClosureValue:
+		for i, capture := range v.Captures {
+			v.Captures[i] = n.normalizeGlobalValue(capture)
+		}
+		return v
 	case *FieldValue:
 		v.Base = n.normalizeGlobalValue(v.Base)
 		return v
@@ -231,6 +236,17 @@ func (n *normalizer) normalizeValue(fn *Function, value Value) ([]Instr, Value) 
 		copy.Callee = callee
 		copy.Args = args
 		return n.wrapComputed(fn, &copy, temps)
+	case *ClosureValue:
+		temps := make([]Instr, 0, len(v.Captures))
+		captures := make([]Value, 0, len(v.Captures))
+		for _, capture := range v.Captures {
+			captureTemps, simpleCapture := n.normalizeValue(fn, capture)
+			temps = append(temps, captureTemps...)
+			captures = append(captures, simpleCapture)
+		}
+		copy := *v
+		copy.Captures = captures
+		return n.wrapComputed(fn, &copy, temps)
 	case *FieldLoadValue:
 		temps, base := n.normalizeValue(fn, v.Base)
 		copy := *v
@@ -331,6 +347,17 @@ func (n *normalizer) normalizeValueInline(fn *Function, value Value) ([]Instr, V
 		copy := *v
 		copy.Callee = callee
 		copy.Args = args
+		return temps, &copy
+	case *ClosureValue:
+		temps := make([]Instr, 0, len(v.Captures))
+		captures := make([]Value, 0, len(v.Captures))
+		for _, capture := range v.Captures {
+			captureTemps, simpleCapture := n.normalizeValue(fn, capture)
+			temps = append(temps, captureTemps...)
+			captures = append(captures, simpleCapture)
+		}
+		copy := *v
+		copy.Captures = captures
 		return temps, &copy
 	case *FieldLoadValue:
 		temps, base := n.normalizeValue(fn, v.Base)

--- a/internal/ir/mir/simplify.go
+++ b/internal/ir/mir/simplify.go
@@ -312,6 +312,11 @@ func simplifyValue(value Value, consts map[int]Value) Value {
 			v.Args[i] = simplifyValue(arg, consts)
 		}
 		return v
+	case *ClosureValue:
+		for i, capture := range v.Captures {
+			v.Captures[i] = simplifyValue(capture, consts)
+		}
+		return v
 	case *FieldLoadValue:
 		v.Base = simplifyValue(v.Base, consts)
 		return v
@@ -373,6 +378,8 @@ func valueMayMutateMemory(value Value) bool {
 		return valueMayMutateMemory(v.Pointer)
 	case *CallValue:
 		return true
+	case *ClosureValue:
+		return slices.ContainsFunc(v.Captures, valueMayMutateMemory)
 	case *FieldLoadValue:
 		return valueMayMutateMemory(v.Base)
 	case *FieldValue:
@@ -788,6 +795,10 @@ func remapValueLocals(value Value, idMap map[int]int) {
 		for _, arg := range v.Args {
 			remapValueLocals(arg, idMap)
 		}
+	case *ClosureValue:
+		for _, capture := range v.Captures {
+			remapValueLocals(capture, idMap)
+		}
 	case *FieldLoadValue:
 		remapValueLocals(v.Base, idMap)
 	case *FieldValue:
@@ -961,6 +972,10 @@ func addUsedLocalsFromValue(dst map[int]bool, value Value) {
 		for _, arg := range v.Args {
 			addUsedLocalsFromValue(dst, arg)
 		}
+	case *ClosureValue:
+		for _, capture := range v.Captures {
+			addUsedLocalsFromValue(dst, capture)
+		}
 	case *FieldLoadValue:
 		addUsedLocalsFromValue(dst, v.Base)
 	case *FieldValue:
@@ -1000,6 +1015,10 @@ func countUsedLocalsInValue(dst map[int]int, value Value) {
 		countUsedLocalsInValue(dst, v.Callee)
 		for _, arg := range v.Args {
 			countUsedLocalsInValue(dst, arg)
+		}
+	case *ClosureValue:
+		for _, capture := range v.Captures {
+			countUsedLocalsInValue(dst, capture)
 		}
 	case *FieldLoadValue:
 		countUsedLocalsInValue(dst, v.Base)
@@ -1113,6 +1132,11 @@ func replaceLocalInValue(value Value, localID int, replacement Value) Value {
 		v.Callee = replaceLocalInValue(v.Callee, localID, replacement)
 		for i, arg := range v.Args {
 			v.Args[i] = replaceLocalInValue(arg, localID, replacement)
+		}
+		return v
+	case *ClosureValue:
+		for i, capture := range v.Captures {
+			v.Captures[i] = replaceLocalInValue(capture, localID, replacement)
 		}
 		return v
 	case *FieldLoadValue:

--- a/internal/ir/mir/validate.go
+++ b/internal/ir/mir/validate.go
@@ -191,6 +191,13 @@ func childrenAreSimple(value Value) bool {
 			}
 		}
 		return true
+	case *ClosureValue:
+		for _, capture := range v.Captures {
+			if !isSimpleValue(capture) {
+				return false
+			}
+		}
+		return true
 	case *FieldLoadValue:
 		return isSimpleValue(v.Base)
 	case *FieldValue:

--- a/internal/tokens/token.go
+++ b/internal/tokens/token.go
@@ -95,6 +95,7 @@ const (
 	AS        Kind = "AS"
 	IS        Kind = "IS"
 	MUT       Kind = "MUT"
+	MOVE      Kind = "MOVE"
 	COMPTIME  Kind = "COMPTIME"
 	LOCK      Kind = "LOCK"
 	DEFER     Kind = "DEFER"
@@ -128,6 +129,7 @@ var keywords = map[string]Kind{
 	"as":        AS,
 	"is":        IS,
 	"mut":       MUT,
+	"move":      MOVE,
 	"comptime":  COMPTIME,
 	"lock":      LOCK,
 	"defer":     DEFER,
@@ -161,6 +163,7 @@ var keywordDocs = map[Kind]string{
 	AS:        "Cast an expression to a target type.",
 	IS:        "Check whether a value conforms to a target type.",
 	MUT:       "Mark a binding or reference as mutable.",
+	MOVE:      "Capture lambda environment by move.",
 	COMPTIME:  "Force compile-time evaluation.",
 	LOCK:      "Acquire a lock guard for the block scope.",
 	DEFER:     "Run a statement when the current scope exits.",


### PR DESCRIPTION
This pull request significantly refactors the ownership and borrow tracking logic in the semantic analysis phase, introducing support for multiple simultaneous borrows and improving lambda capture handling. The changes replace the previous single-borrow model with a more robust structure that can track multiple borrows per value, and they also enhance the typechecker to properly record and validate lambda captures and symbol mutability.

Ownership and borrow tracking improvements:
* Replaces the single-borrow fields (`borrowOf`, `borrowMut`, etc.) in `valueInfo` with a `borrows` slice, allowing multiple borrows to be tracked simultaneously. Adds `borrowSlot` type and supporting functions for equality, cloning, and releasing borrows. Updates all relevant logic to operate on the new structure. [[1]](diffhunk://#diff-6d546143d7e50d1cf4a40bbd12c0f1c1d4109ed4945f36e25f12f2dfc5d03840L20-R33) [[2]](diffhunk://#diff-6d546143d7e50d1cf4a40bbd12c0f1c1d4109ed4945f36e25f12f2dfc5d03840L86-R96) [[3]](diffhunk://#diff-6d546143d7e50d1cf4a40bbd12c0f1c1d4109ed4945f36e25f12f2dfc5d03840L141-R139) [[4]](diffhunk://#diff-6d546143d7e50d1cf4a40bbd12c0f1c1d4109ed4945f36e25f12f2dfc5d03840L181-R182) [[5]](diffhunk://#diff-6d546143d7e50d1cf4a40bbd12c0f1c1d4109ed4945f36e25f12f2dfc5d03840R210-R252)
* Refactors borrow analysis methods to handle multiple borrows, including `bindBorrowValue`, `releaseBorrowValue`, and `borrowValueInfos`. Updates conflict checks and state merging logic to work with the new model. [[1]](diffhunk://#diff-684a96670b9f77ff5f69cc9681d0fac3de43da7db35258004578431d9b6b6cb6L994-R1071) [[2]](diffhunk://#diff-684a96670b9f77ff5f69cc9681d0fac3de43da7db35258004578431d9b6b6cb6L273-R273) [[3]](diffhunk://#diff-684a96670b9f77ff5f69cc9681d0fac3de43da7db35258004578431d9b6b6cb6L694-R694) [[4]](diffhunk://#diff-684a96670b9f77ff5f69cc9681d0fac3de43da7db35258004578431d9b6b6cb6L1212-R1251) [[5]](diffhunk://#diff-684a96670b9f77ff5f69cc9681d0fac3de43da7db35258004578431d9b6b6cb6L1231-R1271) [[6]](diffhunk://#diff-684a96670b9f77ff5f69cc9681d0fac3de43da7db35258004578431d9b6b6cb6L1386-R1492)
* Updates liveness analysis to account for closure captures as potential uses, improving accuracy in borrow tracking for closures.

Lambda capture and symbol mutability enhancements:
* Refactors lambda capture tracking in the typechecker: replaces the `reported` set with `captures` and `captureMut` maps in `lambdaScope`, and adds logic to track mutability requirements for captured symbols. [[1]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aL26-R28) [[2]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aL180-R208) [[3]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aL225-R247) [[4]](diffhunk://#diff-d2f97d84d40ad6c65a0cf0d07643d9e645db45f4684c49a976f94446fecbf867R227-R243)
* Improves symbol mutability checks to consider whether a symbol is captured by a lambda and if it is required to be mutable. Adds logic to report errors for assignments to immutable captured symbols. [[1]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aL138-R141) [[2]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aR160-R176)
* Adds tracking for symbols whose ownership has been moved, including new helpers for marking and querying moved symbols. [[1]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aR289-R324) [[2]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aR371)

Other improvements:
* Adds missing import for `sort` and cleans up imports. [[1]](diffhunk://#diff-cadc849db3b69331e77b4bfc244399b491b569ace424e9d12851b2923e552089R6) [[2]](diffhunk://#diff-476300a32a2880f273047780d4885dfcc7c0780f162729e95ff8f7c6c604d92aL8-R9)

These changes collectively provide a more accurate and robust foundation for borrow checking and lambda analysis in the compiler.